### PR TITLE
fix: ConnectionPool#createConnection: Use correct location of projectId.

### DIFF
--- a/src/connection-pool.js
+++ b/src/connection-pool.js
@@ -63,7 +63,6 @@ var RETRY_CODES = [
 function ConnectionPool(subscription) {
   this.subscription = subscription;
   this.pubsub = subscription.pubsub;
-  this.projectId = subscription.projectId;
 
   this.connections = new Map();
 
@@ -208,7 +207,7 @@ ConnectionPool.prototype.createConnection = function() {
       .write({
         subscription: common.util.replaceProjectIdToken(
           self.subscription.name,
-          self.projectId
+          self.pubsub.projectId
         ),
         streamAckDeadlineSeconds: self.settings.ackDeadline / 1000,
       });

--- a/test/connection-pool.js
+++ b/test/connection-pool.js
@@ -67,9 +67,7 @@ describe('ConnectionPool', function() {
   var PROJECT_ID = 'grapce-spacheship-123';
 
   var PUBSUB = {
-    projectId: PROJECT_ID,
     auth: {
-      projectId: PROJECT_ID,
       getAuthClient: fakeUtil.noop,
     },
     options: FAKE_PUBSUB_OPTIONS,
@@ -77,7 +75,6 @@ describe('ConnectionPool', function() {
 
   var SUB_NAME = 'test-subscription';
   var SUBSCRIPTION = {
-    projectId: PROJECT_ID,
     name: SUB_NAME,
     pubsub: PUBSUB,
     request: fakeUtil.noop,
@@ -136,6 +133,7 @@ describe('ConnectionPool', function() {
       var pool = new ConnectionPool(SUBSCRIPTION);
 
       assert.strictEqual(pool.subscription, SUBSCRIPTION);
+      assert.strictEqual(pool.pubsub, SUBSCRIPTION.pubsub);
       assert(pool.connections instanceof Map);
       assert.strictEqual(pool.isPaused, false);
       assert.strictEqual(pool.isOpen, false);
@@ -365,6 +363,10 @@ describe('ConnectionPool', function() {
       fakeClient.waitForReady = fakeUtil.noop;
 
       pool.getClient = function(callback) {
+        pool.pubsub = {
+          projectId: PROJECT_ID,
+        };
+
         callback(null, fakeClient);
       };
     });


### PR DESCRIPTION
Fixes #23 

The chain:

- ConnectionPool#createConnection() - "I need the GAPIC client"
  - PubSub#getClient() - "I need the project ID"
    - GoogleAutoAuth#getProjectId() - "I'll store the project ID on pubsubInstance.projectID"

The execution path then goes back to where it started, inside ConnectionPool#createConnection. The problem is that function wasn't getting a live representation of the projectId, it was using a local cache it made when it was instantiated.