### PR TITLE
DOC: Fix ackDeadline configuration for subscription

### DIFF
--- a/src/topic.js
+++ b/src/topic.js
@@ -177,7 +177,7 @@ Topic.prototype.create = function(gaxOpts, callback) {
  *
  * // With options.
  * topic.createSubscription('newMessages', {
- *   ackDeadline: 90000 // 90 seconds
+ *   ackDeadlineSeconds: 90
  * }, callback);
  *
  * //-


### PR DESCRIPTION
ackDeadline will not affect new subscription

https://cloud.google.com/pubsub/docs/reference/rest/v1/projects.subscriptions/create

- [x] Tests and linter pass
- [x] Code coverage does not decrease (if any source code was changed)
- [x] Appropriate docs were updated (if necessary)
