### PR TITLE
Remove timeout from unit tests.

### DIFF
--- a/package.json
+++ b/package.json
@@ -49,7 +49,7 @@
   ],
   "scripts": {
     "system-test": "repo-tools test run --cmd mocha -- system-test/*.js --no-timeouts",
-    "cover": "nyc --reporter=lcov mocha --require intelli-espower-loader test/*.js && nyc report",
+    "cover": "nyc --reporter=lcov mocha --require intelli-espower-loader test/*.js --timeout 0 && nyc report",
     "samples-test": "cd samples/ && npm link ../ && npm test && cd ../",
     "test-no-cover": "repo-tools test run --cmd mocha -- test/*.js --no-timeouts",
     "test": "repo-tools test run --cmd npm -- run cover",


### PR DESCRIPTION
We don't need a timeout. It's causing problems in the build, and in the worst case scenario where we forget to call `done()`, the build will timeout and destroy itself.

Reference: https://circleci.com/workflow-run/703f2528-bc45-487d-b246-332d52d76584