### PR TITLE
v0.17.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1937,7 +1937,7 @@
     },
     "@types/node": {
       "version": "8.9.5",
-      "resolved": "http://registry.npmjs.org/@types/node/-/node-8.9.5.tgz",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-8.9.5.tgz",
       "integrity": "sha512-jRHfWsvyMtXdbhnz5CVHxaBgnV6duZnPlQuRSo/dm/GnmikNcmZhxIES4E9OZjUmQ8C+HCl4KJux+cXN/ErGDQ=="
     },
     "acorn": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@google-cloud/pubsub",
-  "version": "0.16.5",
+  "version": "0.17.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@google-cloud/pubsub",
   "description": "Cloud Pub/Sub Client Library for Node.js",
-  "version": "0.16.5",
+  "version": "0.17.0",
   "license": "Apache-2.0",
   "author": "Google Inc.",
   "engines": {

--- a/samples/package-lock.json
+++ b/samples/package-lock.json
@@ -1786,7 +1786,7 @@
       }
     },
     "@google-cloud/pubsub": {
-      "version": "0.16.5",
+      "version": "0.17.0",
       "requires": {
         "@google-cloud/common": "0.16.2",
         "arrify": "1.0.1",

--- a/samples/package.json
+++ b/samples/package.json
@@ -17,7 +17,7 @@
     "test": "repo-tools test run --cmd npm -- run cover"
   },
   "dependencies": {
-    "@google-cloud/pubsub": "0.16.5",
+    "@google-cloud/pubsub": "0.17.0",
     "yargs": "10.0.3"
   },
   "devDependencies": {


### PR DESCRIPTION
## Fixes

* (#96, #97) Lower the default publisher `maxMilliseconds` value.
* (#13, #50, #92) Fix/Improve flow control performance
* (#66, #92) Cancel gRPC stream on `subscription.close()`
* (#88, #99) Prevent duplicate messages from being re-delivered.
* Updated dependencies, including google-gax, to fix streaming behavior. (https://github.com/googleapis/gax-nodejs/pull/197)