### PR TITLE
refactor(subscription): use unary rpcs for ack/modAck

### DIFF
--- a/src/subscriber.js
+++ b/src/subscriber.js
@@ -81,6 +81,10 @@ function Subscriber(options) {
   this.userClosed_ = false;
   this.isOpen = false;
   this.messageListeners = 0;
+
+  // As of right now we do not write any acks/modacks to the pull streams.
+  // But with allowing users to opt out of using streaming pulls altogether on
+  // the horizon, we may need to support this feature again in the near future.
   this.writeToStreams_ = false;
 
   events.EventEmitter.call(this);

--- a/src/subscription.js
+++ b/src/subscription.js
@@ -60,6 +60,10 @@ var Subscriber = require('./subscriber.js');
  * @param {string} name The name of the subscription.
  * @param {object} [options] See a
  *     [Subscription resource](https://cloud.google.com/pubsub/docs/reference/rest/v1/projects.subscriptions)
+ * @param {object} [options.batching] Batch configurations for sending out
+ *     Acknowledge and ModifyAckDeadline requests.
+ * @param {number} [options.batching.maxMilliseconds] The maximum amount of time
+ *     to buffer Acknowledge and ModifyAckDeadline requests. Default: 100.
  * @param {object} [options.flowControl] Flow control configurations for
  *     receiving messages. Note that these options do not persist across
  *     subscription instances.

--- a/test/connection-pool.js
+++ b/test/connection-pool.js
@@ -263,15 +263,30 @@ describe('ConnectionPool', function() {
   });
 
   describe('close', function() {
+    var _clearTimeout;
+    var _clearInterval;
+
+    before(function() {
+      _clearTimeout = global.clearTimeout;
+      _clearInterval = global.clearInterval;
+    });
+
+    beforeEach(function() {
+      global.clearTimeout = global.clearInterval = fakeUtil.noop;
+    });
+
+    afterEach(function() {
+      global.clearTimeout = _clearTimeout;
+      global.clearInterval = _clearInterval;
+    });
+
     it('should stop running the keepAlive task', function(done) {
-      var _clearInterval = global.clearInterval;
       var fakeHandle = 123;
 
       pool.keepAliveHandle = fakeHandle;
 
       global.clearInterval = function(handle) {
         assert.strictEqual(handle, fakeHandle);
-        global.clearInterval = _clearInterval;
         done();
       };
 
@@ -284,7 +299,6 @@ describe('ConnectionPool', function() {
     });
 
     it('should clear any timeouts in the queue', function() {
-      var _clearTimeout = global.clearTimeout;
       var clearCalls = 0;
 
       var fakeHandles = ['a', 'b', 'c', 'd'];
@@ -298,8 +312,6 @@ describe('ConnectionPool', function() {
 
       assert.strictEqual(clearCalls, fakeHandles.length);
       assert.strictEqual(pool.queue.length, 0);
-
-      global.clearTimeout = _clearTimeout;
     });
 
     it('should set isOpen to false', function() {

--- a/test/connection-pool.js
+++ b/test/connection-pool.js
@@ -33,13 +33,16 @@ function FakeConnection() {
   this.isPaused = false;
   this.ended = false;
   this.canceled = false;
+  this.written = [];
 
   events.EventEmitter.call(this);
 }
 
 util.inherits(FakeConnection, events.EventEmitter);
 
-FakeConnection.prototype.write = function() {};
+FakeConnection.prototype.write = function(data) {
+  this.written.push(data);
+};
 
 FakeConnection.prototype.end = function(callback) {
   this.ended = true;
@@ -260,6 +263,21 @@ describe('ConnectionPool', function() {
   });
 
   describe('close', function() {
+    it('should stop running the keepAlive task', function(done) {
+      var _clearInterval = global.clearInterval;
+      var fakeHandle = 123;
+
+      pool.keepAliveHandle = fakeHandle;
+
+      global.clearInterval = function(handle) {
+        assert.strictEqual(handle, fakeHandle);
+        global.clearInterval = _clearInterval;
+        done();
+      };
+
+      pool.close();
+    });
+
     it('should clear the connections map', function(done) {
       pool.connections.clear = done;
       pool.close();
@@ -1078,6 +1096,7 @@ describe('ConnectionPool', function() {
   describe('open', function() {
     beforeEach(function() {
       pool.queueConnection = fakeUtil.noop;
+      clearInterval(pool.keepAliveHandle);
     });
 
     it('should make the specified number of connections', function() {
@@ -1145,6 +1164,31 @@ describe('ConnectionPool', function() {
         pool.isGettingChannelState = true;
         pool.emit('newListener', 'channel.ready');
       });
+    });
+
+    it('should start a keepAlive task', function(done) {
+      var _setInterval = global.setInterval;
+      var unreffed = false;
+      var fakeHandle = {
+        unref: () => (unreffed = true),
+      };
+
+      pool.subscription = {writeToStreams_: false};
+      pool.sendKeepAlives = done;
+
+      global.setInterval = function(fn, interval) {
+        global.setInterval = _setInterval;
+
+        assert.strictEqual(interval, 30000);
+        fn(); // should call sendKeepAlives aka done
+
+        return fakeHandle;
+      };
+
+      pool.open();
+
+      assert.strictEqual(pool.keepAliveHandle, fakeHandle);
+      assert.strictEqual(unreffed, true);
     });
   });
 
@@ -1259,6 +1303,21 @@ describe('ConnectionPool', function() {
 
       assert.strictEqual(a.isPaused, false);
       assert.strictEqual(b.isPaused, false);
+    });
+  });
+
+  describe('sendKeepAlives', function() {
+    it('should write an empty message to all the streams', function() {
+      var a = new FakeConnection();
+      var b = new FakeConnection();
+
+      pool.connections.set('a', a);
+      pool.connections.set('b', b);
+
+      pool.sendKeepAlives();
+
+      assert.deepEqual(a.written, [{}]);
+      assert.deepEqual(b.written, [{}]);
     });
   });
 


### PR DESCRIPTION
Closes #138 

- [x] Tests and linter pass
- [x] Code coverage does not decrease (if any source code was changed)
- [x] Appropriate docs were updated (if necessary)
