### PR TITLE
Fixes 179: Adds missing return statement in docs

### DIFF
--- a/src/topic.js
+++ b/src/topic.js
@@ -547,6 +547,8 @@ Topic.prototype.getSubscriptionsStream = common.paginator.streamify(
  * @param {number} [options.batching.maxMilliseconds] The maximum duration to
  *     wait before sending a payload.
  *
+ * @return {Publisher}
+ *
  * @example
  * const PubSub = require('@google-cloud/pubsub');
  * const pubsub = new PubSub();


### PR DESCRIPTION
Fixes #179 

Added a missing return statement. This change should propagate to the auto-generated docs page.

- [x] Tests and linter pass
- [x] Code coverage does not decrease (if any source code was changed)
- [x] Appropriate docs were updated (if necessary)
