### PR TITLE
Fixes 177: Prevents publishing attributes that have non-string values

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -4,51 +4,39 @@ workflows:
   tests:
     jobs: &workflow_jobs
       - node6:
-          filters:
+          filters: &all_commits
             tags:
               only: /.*/
       - node8:
-          filters:
-            tags:
-              only: /.*/
+          filters: *all_commits
       - node10:
-          filters:
-            tags:
-              only: /.*/
+          filters: *all_commits
       - lint:
           requires:
             - node6
             - node8
             - node10
-          filters:
-            tags:
-              only: /.*/
+          filters: *all_commits
       - docs:
           requires:
             - node6
             - node8
             - node10
-          filters:
-            tags:
-              only: /.*/
+          filters: *all_commits
       - system_tests:
           requires:
             - lint
             - docs
-          filters:
+          filters: &master_and_releases
             branches:
               only: master
-            tags:
+            tags: &releases
               only: '/^v[\d.]+$/'
       - sample_tests:
           requires:
             - lint
             - docs
-          filters:
-            branches:
-              only: master
-            tags:
-              only: '/^v[\d.]+$/'
+          filters: *master_and_releases
       - publish_npm:
           requires:
             - system_tests
@@ -56,8 +44,7 @@ workflows:
           filters:
             branches:
               ignore: /.*/
-            tags:
-              only: '/^v[\d.]+$/'
+            tags: *releases
   nightly:
     triggers:
       - schedule:
@@ -85,14 +72,15 @@ jobs:
               echo "Not a nightly build, skipping this step."
             fi
       - run: &npm_install_and_link
-          name: Install and link the module.
-          command: |
-            mkdir /home/node/.npm-global
+          name: Install and link the module
+          command: |-
+            mkdir -p /home/node/.npm-global
             npm install
           environment:
             NPM_CONFIG_PREFIX: /home/node/.npm-global
       - run: npm test
       - run: node_modules/.bin/codecov
+  
   node8:
     docker:
       - image: 'node:8'
@@ -115,8 +103,8 @@ jobs:
           name: Link the module being tested to the samples.
           command: |
             cd samples/
-            npm install
             npm link ../
+            npm install
           environment:
             NPM_CONFIG_PREFIX: /home/node/.npm-global
       - run:
@@ -155,13 +143,13 @@ jobs:
           command: npm run samples-test
           environment:
             GCLOUD_PROJECT: long-door-651
-            GOOGLE_APPLICATION_CREDENTIALS: /home/node/pubsub-samples/.circleci/key.json
+            GOOGLE_APPLICATION_CREDENTIALS: /home/node/samples/.circleci/key.json
             NPM_CONFIG_PREFIX: /home/node/.npm-global
       - run:
           name: Remove unencrypted key.
           command: rm .circleci/key.json
           when: always
-    working_directory: /home/node/pubsub-samples
+    working_directory: /home/node/samples/
   system_tests:
     docker:
       - image: 'node:8'
@@ -192,4 +180,4 @@ jobs:
     steps:
       - checkout
       - run: 'echo "//registry.npmjs.org/:_authToken=${NPM_TOKEN}" > ~/.npmrc'
-      - run: npm publish
+      - run: npm publish --access=public

--- a/samples/package.json
+++ b/samples/package.json
@@ -9,7 +9,7 @@
     "url": "https://github.com/googleapis/nodejs-pubsub.git"
   },
   "engines": {
-    "node": ">=8.0.0"
+    "node": ">=8"
   },
   "scripts": {
     "ava": "ava -T 20s --verbose system-test/*.test.js",

--- a/src/publisher.js
+++ b/src/publisher.js
@@ -109,12 +109,11 @@ function Publisher(topic, options) {
  * Publish the provided message.
  *
  * @throws {TypeError} If data is not a Buffer object.
- * @throws {TypeError} If any value in attributes is not a string.
+ * @throws {TypeError} If any value in `attributes` object is not a string.
  *
  * @param {buffer} data The message data. This must come in the form of a
  *     Buffer object.
- * @param {object} [attributes] Optional attributes for this message. The values
- *     of the object must come in the form of a string.
+ * @param {object.<string, string>} [attributes] Attributes for this message.
  * @param {PublisherPublishCallback} [callback] Callback function.
  * @returns {Promise<PublisherPublishResponse>}
  *
@@ -164,11 +163,9 @@ Publisher.prototype.publish = function(data, attributes, callback) {
   for (var key in attributes) {
     var value = attributes[key];
 
-    if (typeof value !== 'string') {
-      throw new TypeError(
-        'All attributes must be in the form of a string. Invalid value: ' +
-          JSON.stringify(value)
-      );
+    if (!is.string(value)) {
+      throw new TypeError(`All attributes must be in the form of a string.
+\nInvalid value of type "${typeof value}" provided for "${key}".`);
     }
   }
 

--- a/synth.py
+++ b/synth.py
@@ -6,6 +6,7 @@ import subprocess
 logging.basicConfig(level=logging.DEBUG)
 
 gapic = gcp.GAPICGenerator()
+common_templates = gcp.CommonTemplates()
 
 # tasks has two product names, and a poorly named artman yaml
 version = 'v1'
@@ -16,6 +17,10 @@ library = gapic.node_library(
 s.copy(
     library,
     excludes=['package.json', 'README.md', 'src/index.js'])
+
+templates = common_templates.node_library(package_name="@google-cloud/pubsub")
+s.copy(templates)
+
 
 # https://github.com/googleapis/gapic-generator/issues/2127
 s.replace("src/v1/subscriber_client.js",

--- a/test/publisher.js
+++ b/test/publisher.js
@@ -153,19 +153,24 @@ describe('Publisher', function() {
 
     it('should throw an error when data is not a buffer', function() {
       assert.throws(function() {
-        publisher.publish('hello', {}, fakeUtil.noop);
+        publisher.publish('hello', {}, assert.ifError);
       }, /Data must be in the form of a Buffer\./);
     });
 
-    it('should throw an error when any attribute value is not a string', function() {
+    it('should throw when an attribute value is not a string', function() {
       var brokenAttrs = {
         key1: 'value',
         key2: true,
       };
 
+      var expectedErrorMessage = `
+All attributes must be in the form of a string.
+\nInvalid value of type "${typeof true}" provided for "key2".
+      `.trim();
+
       assert.throws(function() {
-        publisher.publish(DATA, brokenAttrs, fakeUtil.noop);
-      });
+        publisher.publish(DATA, brokenAttrs, assert.ifError);
+      }, expectedErrorMessage);
     });
 
     it('should queue the data', function(done) {

--- a/test/publisher.js
+++ b/test/publisher.js
@@ -170,7 +170,7 @@ All attributes must be in the form of a string.
 
       assert.throws(function() {
         publisher.publish(DATA, brokenAttrs, assert.ifError);
-      }, expectedErrorMessage);
+      }, new RegExp(expectedErrorMessage));
     });
 
     it('should queue the data', function(done) {


### PR DESCRIPTION
Fixes #177 

If the attributes object has non-string values, publishing fails.
This change adds extra checks to ensure all values are string typed.
Additionally, this precondition is documented.

Testing Done:
- [x] Added a new unit test and ran the test suite
- [x] Ensured the docs contain the new information
- [x] Checked code coverage
- [x] Ran eslint
- [x] Manual testing
