### PR TITLE
Pub/Sub Synchronous Pull Example

### DIFF
--- a/samples/subscriptions.js
+++ b/samples/subscriptions.js
@@ -334,8 +334,9 @@ function synchronousPull(projectName, subscriptionName) {
   // const subscriptionName = 'your-subscription';
 
   const formattedSubscription = client.subscriptionPath(
-    projectName, 
-    subscriptionName);
+    projectName,
+    subscriptionName
+  );
   // The maximum number of messages returned for this request.
   // Pub/Sub may return fewer than the number specified.
   const maxMessages = 3;
@@ -345,7 +346,8 @@ function synchronousPull(projectName, subscriptionName) {
   };
 
   // The subscriber pulls a specific number of messages.
-  client.pull(request)
+  client
+    .pull(request)
     .then(responses => {
     
       // The first element of `responses` is a PullResponse object.
@@ -384,7 +386,8 @@ function synchronousPull(projectName, subscriptionName) {
             console.log(
               `Reset ack deadline for "${
                 message.message.data
-              }" for ${ackDeadlineSeconds}s.`);
+              }" for ${ackDeadlineSeconds}s.`
+            );
           }
         }
       });

--- a/samples/subscriptions.js
+++ b/samples/subscriptions.js
@@ -381,7 +381,7 @@ function synchronousPull(projectName, subscriptionName) {
             client.modifyAckDeadline(modifyAckRequest).catch(err => {
               console.error(err);
             });
-            console.log(`
+            console.log(
               `Reset ack deadline for "${
                 message.message.data
               }" for ${ackDeadlineSeconds}s.`);

--- a/samples/subscriptions.js
+++ b/samples/subscriptions.js
@@ -349,7 +349,6 @@ function synchronousPull(projectName, subscriptionName) {
   client
     .pull(request)
     .then(responses => {
-    
       // The first element of `responses` is a PullResponse object.
       const response = responses[0];
 

--- a/samples/subscriptions.js
+++ b/samples/subscriptions.js
@@ -325,7 +325,7 @@ function synchronousPull(projectName, subscriptionName) {
   // Imports the Google Cloud client library
   const pubsub = require('@google-cloud/pubsub');
 
-  var client = new pubsub.v1.SubscriberClient();
+  const client = new pubsub.v1.SubscriberClient();
 
   /**
    * TODO(developer): Uncomment the following lines to run the sample.
@@ -333,30 +333,29 @@ function synchronousPull(projectName, subscriptionName) {
   // const projectName = 'your-project';
   // const subscriptionName = 'your-subscription';
 
-  const formattedSubscription = client.subscriptionPath(
-    projectName, subscriptionName);
+  const formattedSubscription = client.subscriptionPath(projectName, 
+                                                        subscriptionName);
   // The maximum number of messages returned for this request.
   // Pub/Sub may return fewer than the number specified.
   const maxMessages = 3;
   const request = {
     subscription: formattedSubscription,
-    maxMessages: maxMessages
+    maxMessages: maxMessages,
   };
 
   // The subscriber pulls a specific number of messages.
   client.pull(request)
     .then(responses => {
       // The first element of `responses` is a PullResponse object.
-      var response = responses[0];
+      const response = responses[0];
 
       // Process each received message in `response`.
       response.receivedMessages.forEach(message => {
-
         // Create an arbitrarily large integer `target` to help
         // simulate a long-running process.
-        var target = Math.floor(Math.random()*1e9);
-        var ackDeadlineSeconds = 30;
-        var modifyAckRequest = {
+        const target = Math.floor(Math.random() * 1e9);
+        const ackDeadlineSeconds = 30;
+        const modifyAckRequest = {
           subscription: formattedSubscription,
           ackIds: [message.ackId],
           ackDeadlineSeconds: ackDeadlineSeconds,
@@ -367,7 +366,7 @@ function synchronousPull(projectName, subscriptionName) {
           // If `i` reaches `target`, we assume the message has been
           // processed, so we ack it. Else, we assume the message is
           // still being processed, so we modify its ack deadline.
-          if (i == target) {
+          if (i === target) {
             const ackRequest = {
               subscription: formattedSubscription,
               ackIds: [message.ackId],
@@ -376,16 +375,15 @@ function synchronousPull(projectName, subscriptionName) {
               console.error(err);
             });
             console.log(`Acknowledged "${message.message.data}".`);
-          } else if (i % 1e8 == 0) {
+          } else if (i % 1e8 === 0) {
             client.modifyAckDeadline(modifyAckRequest).catch(err => {
               console.error(err);
             });
-            console.log(`Reset ack deadline for "${
-              message.message.data}" for ${ackDeadlineSeconds}s.`);
+            console.log(`Reset ack deadline for "${message.message.data}" for ${ackDeadlineSeconds}s.`);
           }
-        };
+        }
       });
-      console.log("Done.");
+      console.log(`Done.`);
     })
     .catch(err => {
       console.error(err);

--- a/samples/subscriptions.js
+++ b/samples/subscriptions.js
@@ -333,8 +333,9 @@ function synchronousPull(projectName, subscriptionName) {
   // const projectName = 'your-project';
   // const subscriptionName = 'your-subscription';
 
-  const formattedSubscription = client.subscriptionPath(projectName, 
-                                                        subscriptionName);
+  const formattedSubscription = client.subscriptionPath(
+    projectName, 
+    subscriptionName);
   // The maximum number of messages returned for this request.
   // Pub/Sub may return fewer than the number specified.
   const maxMessages = 3;
@@ -346,6 +347,7 @@ function synchronousPull(projectName, subscriptionName) {
   // The subscriber pulls a specific number of messages.
   client.pull(request)
     .then(responses => {
+    
       // The first element of `responses` is a PullResponse object.
       const response = responses[0];
 
@@ -362,7 +364,7 @@ function synchronousPull(projectName, subscriptionName) {
         };
 
         // Start a long-running process.
-        for (var i = 1; i <= target; i++) {
+        for (let i = 1; i <= target; i++) {
           // If `i` reaches `target`, we assume the message has been
           // processed, so we ack it. Else, we assume the message is
           // still being processed, so we modify its ack deadline.
@@ -379,7 +381,10 @@ function synchronousPull(projectName, subscriptionName) {
             client.modifyAckDeadline(modifyAckRequest).catch(err => {
               console.error(err);
             });
-            console.log(`Reset ack deadline for "${message.message.data}" for ${ackDeadlineSeconds}s.`);
+            console.log(`
+              `Reset ack deadline for "${
+                message.message.data
+              }" for ${ackDeadlineSeconds}s.`);
           }
         }
       });

--- a/samples/system-test/subscriptions.test.js
+++ b/samples/system-test/subscriptions.test.js
@@ -161,7 +161,7 @@ test.serial(`should listen for messages`, async t => {
 });
 
 test.serial(`should listen for messages synchronously`, async t => {
-  const messageIds = await pubsub
+  await pubsub
     .topic(topicNameOne)
     .publisher()
     .publish(Buffer.from(`Hello, world!`));

--- a/samples/system-test/subscriptions.test.js
+++ b/samples/system-test/subscriptions.test.js
@@ -160,6 +160,18 @@ test.serial(`should listen for messages`, async t => {
   t.true(output.includes(`Received message ${messageIds}:`));
 });
 
+test.serial(`should listen for messages synchronously`, async t => {
+  const messageIds = await pubsub
+    .topic(topicNameOne)
+    .publisher()
+    .publish(Buffer.from(`Hello, world!`));
+  const output = await tools.runAsync(
+    `${cmd} sync-pull ${projectId} ${subscriptionNameOne}`,
+    cwd
+  );
+  t.true(output.includes(`Done.`));
+});
+
 test.serial(`should listen for ordered messages`, async t => {
   const timeout = 5;
   const subscriptions = require('../subscriptions');


### PR DESCRIPTION
The desired output would look something like this (to show users that they can use `modifyAckDeadline` to reset the ack deadline while waiting for the message to get processed):

```
Reset ack deadline for "m4" for 30s.
Reset ack deadline for "m4" for 30s.
Reset ack deadline for "m4" for 30s.
Acknowledged "m4".
Reset ack deadline for "m1" for 30s.
Reset ack deadline for "m1" for 30s.
Reset ack deadline for "m1" for 30s.
Reset ack deadline for "m1" for 30s.
Reset ack deadline for "m1" for 30s.
Reset ack deadline for "m1" for 30s.
Reset ack deadline for "m1" for 30s.
Reset ack deadline for "m1" for 30s.
Reset ack deadline for "m1" for 30s.
Acknowledged "m1".
Done.
```