### PR TITLE
(New) Synchronous Pull with Lease Management 

### DIFF
--- a/samples/subscriptions.js
+++ b/samples/subscriptions.js
@@ -347,19 +347,19 @@ function synchronousPull(projectName, subscriptionName) {
   };
   // `messages` is a dict that stores message ack ids as keys, and message
   // data and the processing states (true if done, false if not) as values.
-  var messages = {};
+  let messages = {};
 
   // The worker function takes a message and starts a long-running process.
   function worker(message) {
-    const target = Math.floor(Math.random()*1e5);
-    console.log(`Processing "${message.message.data}" for ${target/1e3}s...`);
+    const target = Math.floor(Math.random() * 1e5);
+    console.log(`Processing "${message.message.data}" for ${target / 1e3}s...`);
 
-    setTimeout(() =>{
-      console.log(`Finished procesing "${message.message.data}".`)
+    setTimeout(() => {
+      console.log(`Finished procesing "${message.message.data}".`);
       // After the message has been processed, set its processing state to true.
       messages[message.ackId][1] = true;
     }, target);
-  };
+  }
 
   // The subscriber pulls a specific number of messages.
   client
@@ -371,7 +371,7 @@ function synchronousPull(projectName, subscriptionName) {
       // Initialize `messages` with message ackId, message data and `false` as
       // processing state. Then, start each message in a worker function.
       response.receivedMessages.forEach(message => {
-        messages[message.ackId]=[message.message.data, false];
+        messages[message.ackId] = [message.message.data, false];
         worker(message);
       });
 
@@ -380,7 +380,7 @@ function synchronousPull(projectName, subscriptionName) {
       // setInterval() gets run every 10s.
       const interval = setInterval(function() {
         // Every 10s, we do a check on the processing states of the messages.
-        Object.keys(messages).forEach( ackId => {
+        Object.keys(messages).forEach(ackId => {
           if (messages[ackId][1]) {
             // If the processing state for a particular message is true,
             // We will ack the message.
@@ -418,13 +418,13 @@ function synchronousPull(projectName, subscriptionName) {
                 messages[ackId][0]
               }" for ${ackDeadlineSeconds}s.`
             );
-          };
+          }
 
           // If all messages have been processed, we clear out of the interval.
-          if (numProcessed === response.receivedMessages.length){
+          if (numProcessed === response.receivedMessages.length) {
             clearInterval(interval);
             console.log(`Done.`);
-          };
+          }
         });
       }, 10000);
     })

--- a/samples/subscriptions.js
+++ b/samples/subscriptions.js
@@ -375,11 +375,8 @@ function synchronousPull(projectName, subscriptionName) {
       // setInterval() gets run every 10s. Every 10s, we check
       // if all the messages have been processed. We will ack those
       // that are processed, and modify the ack deadline for those
-      // that are still being processed.  
+      // that are still being processed.
       const interval = setInterval(function() {
-
-        var alldone = false;
-
         response.receivedMessages.forEach( message => {
           if (processes[message.ackId]) {
             const ackRequest = {
@@ -390,8 +387,6 @@ function synchronousPull(projectName, subscriptionName) {
               console.error(err);
             });
             console.log(`Acknowledged "${message.message.data}".`);
-
-            alldone |= true;
 
             delete processes[message.ackId];
 
@@ -411,13 +406,12 @@ function synchronousPull(projectName, subscriptionName) {
                 message.message.data
               }" for ${ackDeadlineSeconds}s.`
             );
-
-            alldone |= false;
           }
         });
-        if (alldone){
+
+        if (Object.keys(processes).every(function(k){ return processes[k] })){
           clearInterval(interval);
-        }
+        };
       }, 10000);
     })
     .catch(err => {

--- a/samples/subscriptions.js
+++ b/samples/subscriptions.js
@@ -347,7 +347,7 @@ function synchronousPull(projectName, subscriptionName) {
   };
   // `messages` is a dict that stores message ack ids as keys, and message
   // data and the processing states (true if done, false if not) as values.
-  let messages = {};
+  const messages = {};
 
   // The worker function takes a message and starts a long-running process.
   function worker(message) {


### PR DESCRIPTION
This new code sample for synchronous pull with lease management aims to keep the Pub/Sub logic and the application logic separate, by 

1). creating the long running process outside in a worker function, and using `setTimeout` to simulate this process of unknown length; 
2). making use of `setInterval` instead of a `for` loop. 

Here is what the stdout would look like:
```
Processing "hello me" for 60.227s...
Processing "hello him" for 95.585s...
Reset ack deadline for "hello me" for 30s.
Reset ack deadline for "hello him" for 30s.
Reset ack deadline for "hello me" for 30s.
Reset ack deadline for "hello him" for 30s.
Reset ack deadline for "hello me" for 30s.
Reset ack deadline for "hello him" for 30s.
Reset ack deadline for "hello me" for 30s.
Reset ack deadline for "hello him" for 30s.
Reset ack deadline for "hello me" for 30s.
Reset ack deadline for "hello him" for 30s.
Reset ack deadline for "hello me" for 30s.
Reset ack deadline for "hello him" for 30s.
Finished procesing "hello me".
Acknowledged: "hello me".
Reset ack deadline for "hello him" for 30s.
Reset ack deadline for "hello him" for 30s.
Reset ack deadline for "hello him" for 30s.
Finished procesing "hello him".
Acknowledged: "hello him".
Done.
```