### PR TITLE
chore: adjust samples timeout

### DIFF
--- a/samples/package.json
+++ b/samples/package.json
@@ -12,8 +12,8 @@
     "node": ">=8"
   },
   "scripts": {
-    "ava": "ava -T 20s --verbose system-test/*.test.js",
-    "cover": "nyc --reporter=lcov --cache ava -T 20s --verbose test/*.test.js system-test/*.test.js && nyc report",
+    "ava": "ava -T 10m --verbose system-test/*.test.js",
+    "cover": "nyc --reporter=lcov --cache ava -T 10m --verbose test/*.test.js system-test/*.test.js && nyc report",
     "test": "npm run cover"
   },
   "dependencies": {

--- a/samples/subscriptions.js
+++ b/samples/subscriptions.js
@@ -312,10 +312,13 @@ function listenForMessages(subscriptionName, timeout) {
 
   // Listen for new messages until timeout is hit
   subscription.on(`message`, messageHandler);
-  setTimeout(() => {
-    subscription.removeListener('message', messageHandler);
-    console.log(`${messageCount} message(s) received.`);
-  }, timeout * 1000);
+
+  if (timeout) {
+    setTimeout(() => {
+      subscription.removeListener('message', messageHandler);
+      console.log(`${messageCount} message(s) received.`);
+    }, timeout * 1000);
+  }
   // [END pubsub_subscriber_async_pull]
   // [END pubsub_quickstart_subscriber]
 }
@@ -544,10 +547,13 @@ function listenForErrors(subscriptionName, timeout) {
   // Listen for new messages/errors until timeout is hit
   subscription.on(`message`, messageHandler);
   subscription.on(`error`, errorHandler);
-  setTimeout(() => {
-    subscription.removeListener(`message`, messageHandler);
-    subscription.removeListener(`error`, errorHandler);
-  }, timeout * 1000);
+
+  if (timeout) {
+    setTimeout(() => {
+      subscription.removeListener(`message`, messageHandler);
+      subscription.removeListener(`error`, errorHandler);
+    }, timeout * 1000);
+  }
   // [END pubsub_subscriber_error_listener]
 }
 

--- a/samples/subscriptions.js
+++ b/samples/subscriptions.js
@@ -313,12 +313,10 @@ function listenForMessages(subscriptionName, timeout) {
   // Listen for new messages until timeout is hit
   subscription.on(`message`, messageHandler);
 
-  if (timeout) {
-    setTimeout(() => {
-      subscription.removeListener('message', messageHandler);
-      console.log(`${messageCount} message(s) received.`);
-    }, timeout * 1000);
-  }
+  setTimeout(() => {
+    subscription.removeListener('message', messageHandler);
+    console.log(`${messageCount} message(s) received.`);
+  }, timeout * 1000);
   // [END pubsub_subscriber_async_pull]
   // [END pubsub_quickstart_subscriber]
 }
@@ -548,12 +546,10 @@ function listenForErrors(subscriptionName, timeout) {
   subscription.on(`message`, messageHandler);
   subscription.on(`error`, errorHandler);
 
-  if (timeout) {
-    setTimeout(() => {
-      subscription.removeListener(`message`, messageHandler);
-      subscription.removeListener(`error`, errorHandler);
-    }, timeout * 1000);
-  }
+  setTimeout(() => {
+    subscription.removeListener(`message`, messageHandler);
+    subscription.removeListener(`error`, errorHandler);
+  }, timeout * 1000);
   // [END pubsub_subscriber_error_listener]
 }
 

--- a/samples/system-test/subscriptions.test.js
+++ b/samples/system-test/subscriptions.test.js
@@ -226,7 +226,7 @@ test.serial(`should listen for ordered messages`, async t => {
 
 test.serial(`should listen for error messages`, async t => {
   const output = await tools.runAsyncWithIO(
-    `${cmd} listen-errors nonexistent-subscription -t 3`,
+    `${cmd} listen-errors nonexistent-subscription`,
     cwd
   );
   t.true(output.stderr.includes(`Resource not found`));


### PR DESCRIPTION
It looks like our [samples have been timing out](https://circleci.com/gh/googleapis/nodejs-pubsub/5882) for some time. I took a quick look and it seems that a couple of our tests sometimes take well over a minute to complete. I've adjusted the ava timeout to match our system tests timeout (10 minutes).

I also noticed that some commands accept a `timeout` argument, this ended up superseding the ava timeout causing some tests to exit early and fail.