### PR TITLE
chore: ts-ignoring some stuff in tests

### DIFF
--- a/package.json
+++ b/package.json
@@ -71,7 +71,7 @@
     "@types/is": "0.0.21",
     "@types/mocha": "^5.2.5",
     "@types/proxyquire": "^1.3.28",
-    "@types/sinon": "^5.0.5",
+    "@types/sinon": "^5.0.6",
     "@types/through2": "^2.0.34",
     "@types/uuid": "^3.4.4",
     "codecov": "^3.0.0",

--- a/test/connection-pool.ts
+++ b/test/connection-pool.ts
@@ -164,6 +164,7 @@ describe('ConnectionPool', function() {
 
   describe('initialization', function() {
     it('should initialize internally used properties', function() {
+      // @ts-ignore TS2349: Cannot invoke an expression whose type lacks a call signature. Type '((obj: any) => SinonStub<any[], any>) | ((obj: {}) => SinonStub<unknown[], {}>)' has no compatible call signatures.
       sandbox.stub(ConnectionPool.prototype, 'open').returns(undefined);
       const pool = new ConnectionPool(SUBSCRIPTION);
       assert.strictEqual(pool.subscription, SUBSCRIPTION);

--- a/test/connection-pool.ts
+++ b/test/connection-pool.ts
@@ -22,6 +22,7 @@ import * as proxyquire from 'proxyquire';
 import * as uuid from 'uuid';
 import * as pjy from '@google-cloud/projectify';
 import * as sinon from 'sinon';
+import { SinonStub } from 'sinon';
 
 let noopOverride: Function|null = null;
 const fakeUtil = {
@@ -164,8 +165,11 @@ describe('ConnectionPool', function() {
 
   describe('initialization', function() {
     it('should initialize internally used properties', function() {
-      // @ts-ignore TS2349: Cannot invoke an expression whose type lacks a call signature. Type '((obj: any) => SinonStub<any[], any>) | ((obj: {}) => SinonStub<unknown[], {}>)' has no compatible call signatures.
-      sandbox.stub(ConnectionPool.prototype, 'open').returns(undefined);
+      // tslint:disable-next-line:no-any
+      (sandbox as any)
+        .stub(ConnectionPool.prototype, 'open')
+        .returns(undefined);
+
       const pool = new ConnectionPool(SUBSCRIPTION);
       assert.strictEqual(pool.subscription, SUBSCRIPTION);
       assert.strictEqual(pool.pubsub, SUBSCRIPTION.pubsub);

--- a/test/subscription.ts
+++ b/test/subscription.ts
@@ -337,8 +337,7 @@ describe('Subscription', function() {
       });
 
       it('should optionally accept a callback', function(done) {
-        // @ts-ignore TS2345: Argument of type '(err: any, resp: any) => void' is not assignable to parameter of type '() => void'.
-        sandbox.stub(util, 'noop').callsFake((err, resp) => {
+        sandbox.stub(util, 'noop').callsFake((err?, resp?) => {
           assert.ifError(err);
           assert.strictEqual(resp, apiResponse);
           done();

--- a/test/subscription.ts
+++ b/test/subscription.ts
@@ -337,6 +337,7 @@ describe('Subscription', function() {
       });
 
       it('should optionally accept a callback', function(done) {
+        // @ts-ignore TS2345: Argument of type '(err: any, resp: any) => void' is not assignable to parameter of type '() => void'.
         sandbox.stub(util, 'noop').callsFake((err, resp) => {
           assert.ifError(err);
           assert.strictEqual(resp, apiResponse);


### PR DESCRIPTION
These lines in test cause `tsc` errors both locally and in [gax system tests](https://circleci.com/gh/googleapis/gax-nodejs/4888). No idea why/how it passes in Pub/Sub CI but anyway, let's `@ts-ignore` failing lines for now.

- [x] Tests and linter pass
- [x] Code coverage does not decrease (if any source code was changed)
- [x] Appropriate docs were updated (if necessary)
