### PR TITLE
Add migration for v0.20.0 from v0.19.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -163,6 +163,21 @@ const pubsub = new PubSub();
 
 *BREAKING CHANGE*: - fix: drop support for node.js 4.x and 9.x (#171)
 
+
+**BREAKING CHANGE**
+`@google-cloud/pubsub` now requires `new`.
+
+Before:
+```javascript
+const PubSub = require('@google-cloud/pubsub');
+const pubsub = PubSub();
+```
+Now:
+```javascript
+const PubSub = require('@google-cloud/pubsub');
+const pubsub = new PubSub();
+```
+
 ### New Features
 
 - Re-generate library using /synth.py (#227)


### PR DESCRIPTION
It was reported that when upgrading from v0.19 to v0.20 an error about requiring new was exposed. Adding a note about this change to the changelog

Fixes #<issue_number_goes_here> (it's a good idea to open an issue first for discussion)

- [ ] Tests and linter pass
- [ ] Code coverage does not decrease (if any source code was changed)
- [ ] Appropriate docs were updated (if necessary)
