### PR TITLE
fix(docs): add subscription expiration policy docs

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -255,6 +255,8 @@ export class PubSub {
    * @property {boolean} [retainAckedMessages=false] If set, acked messages
    *     are retained in the subscription's backlog for the length of time
    *     specified by `options.messageRetentionDuration`.
+   * @property {ExpirationPolicy} [expirationPolicy] A policy that specifies
+   * the conditions for this subscription's expiration.
    */
   /**
    * Create a subscription to a topic.

--- a/src/subscription.ts
+++ b/src/subscription.ts
@@ -28,6 +28,26 @@ import {PubSub, Metadata} from '.';
 import extend = require('extend');
 
 /**
+ * @typedef {object} ExpirationPolicy
+ * A policy that specifies the conditions for this subscription's expiration. A
+ * subscription is considered active as long as any connected subscriber is
+ * successfully consuming messages from the subscription or is issuing
+ * operations on the subscription. If expirationPolicy is not set, a default
+ * policy with ttl of 31 days will be used. The minimum allowed value for
+ * expirationPolicy.ttl is 1 day. BETA: This feature is part of a beta release.
+ * This API might be changed in backward-incompatible ways and is not
+ * recommended for production use. It is not subject to any SLA or deprecation
+ * policy.
+ * @property {string} ttl Specifies the "time-to-live" duration for an associated
+ * resource. The resource expires if it is not active for a period of ttl. The
+ * eeedefinition of "activity" depends on the type of the associated resource.
+ * The minimum and maximum allowed values for ttl depend on the type of the
+ * associated resource, as well. If ttl is not set, the associated resource never
+ * expires. A duration in seconds with up to nine fractional digits, terminated
+ * by 's'. Example: "3.5s".
+ */
+
+/**
  * @see https://cloud.google.com/pubsub/docs/reference/rest/v1/projects.subscriptions#PushConfig
  */
 export interface PushConfig {

--- a/src/subscription.ts
+++ b/src/subscription.ts
@@ -42,9 +42,9 @@ import extend = require('extend');
  * resource. The resource expires if it is not active for a period of ttl. The
  * eeedefinition of "activity" depends on the type of the associated resource.
  * The minimum and maximum allowed values for ttl depend on the type of the
- * associated resource, as well. If ttl is not set, the associated resource never
- * expires. A duration in seconds with up to nine fractional digits, terminated
- * by 's'. Example: "3.5s".
+ * associated resource, as well. If ttl is not set, the associated resource
+ * never expires. A duration in seconds with up to nine fractional digits,
+ * terminated by 's'. Example: "3.5s".
  */
 
 /**


### PR DESCRIPTION
This was a new feature added to the API - however since we have a separate set of docs for the manual layer of this library, we would often miss changes to the request configs. We need a way to not have to maintain two separate sets of config objects.