### PR TITLE
fix: add getSubscriberStub to synth file

### DIFF
--- a/synth.py
+++ b/synth.py
@@ -31,6 +31,9 @@ s.replace("src/v1/subscriber_client.js",
           "        callback\n"
           "      );\n"
           "    };\n"
+          "    this.getSubscriberStub = function() {\n"
+          "      return subscriberStub;\n"
+          "    };\n"
           "\g<0>")
 
 # Update path discovery due to build/ dir and TypeScript conversion.


### PR DESCRIPTION
Relates to #424 

I never realized this is how we got edits into our gapics 😢 I left a comment on an open issue (https://github.com/googleapis/gapic-generator/issues/2127#issuecomment-454435401)  that might help us remove this in the future.