### PR TITLE
refactor(topic): localize publisher to topic instance

### DIFF
--- a/samples/system-test/subscriptions.test.js
+++ b/samples/system-test/subscriptions.test.js
@@ -109,17 +109,13 @@ describe('subscriptions', () => {
   it('should listen for messages', async () => {
     const messageIds = await pubsub
       .topic(topicNameOne)
-      .publisher()
       .publish(Buffer.from(`Hello, world!`));
     const output = await exec(`${cmd} listen-messages ${subscriptionNameOne}`);
     assert.match(output, new RegExp(`Received message ${messageIds}:`));
   });
 
   it('should listen for messages synchronously', async () => {
-    pubsub
-      .topic(topicNameOne)
-      .publisher()
-      .publish(Buffer.from(`Hello, world!`));
+    pubsub.topic(topicNameOne).publish(Buffer.from(`Hello, world!`));
     const output = await exec(
       `${cmd} sync-pull ${projectId} ${subscriptionNameOne}`
     );
@@ -138,13 +134,11 @@ describe('subscriptions', () => {
     const expected = `Hello, world!`;
     const expectedBuffer = Buffer.from(expected);
     const publishedMessageIds = [];
-    const publisherTwo = pubsub.topic(topicNameTwo).publisher();
+    const topicTwo = pubsub.topic(topicNameTwo);
 
-    await pubsub
-      .topic(topicNameTwo)
-      .subscription(subscriptionNameThree)
-      .get({autoCreate: true});
-    let result = await publisherTwo.publish(expectedBuffer, {counterId: '3'});
+    await topicTwo.subscription(subscriptionNameThree).get({autoCreate: true});
+
+    let result = await topicTwo.publish(expectedBuffer, {counterId: '3'});
     publishedMessageIds.push(result);
     await subscriptions.listenForOrderedMessages(
       subscriptionNameThree,
@@ -152,7 +146,7 @@ describe('subscriptions', () => {
     );
     assert.strictEqual(spy.calls.length, 0);
 
-    result = await publisherTwo.publish(expectedBuffer, {counterId: '1'});
+    result = await topicTwo.publish(expectedBuffer, {counterId: '1'});
     publishedMessageIds.push(result);
     await subscriptions.listenForOrderedMessages(
       subscriptionNameThree,
@@ -166,8 +160,8 @@ describe('subscriptions', () => {
       {counterId: '1'},
     ]);
 
-    result = await publisherTwo.publish(expectedBuffer, {counterId: '1'});
-    result = await publisherTwo.publish(expectedBuffer, {counterId: '2'});
+    result = await topicTwo.publish(expectedBuffer, {counterId: '1'});
+    result = await topicTwo.publish(expectedBuffer, {counterId: '2'});
     publishedMessageIds.push(result);
     await subscriptions.listenForOrderedMessages(
       subscriptionNameThree,

--- a/samples/topics.js
+++ b/samples/topics.js
@@ -96,10 +96,7 @@ async function publishMessage(topicName, data) {
   // Publishes the message as a string, e.g. "Hello, world!" or JSON.stringify(someObject)
   const dataBuffer = Buffer.from(data);
 
-  const messageId = await pubsub
-    .topic(topicName)
-    .publisher()
-    .publish(dataBuffer);
+  const messageId = await pubsub.topic(topicName).publish(dataBuffer);
   console.log(`Message ${messageId} published.`);
 
   // [END pubsub_publish]
@@ -130,7 +127,6 @@ async function publishMessageWithCustomAttributes(topicName, data) {
 
   const messageId = await pubsub
     .topic(topicName)
-    .publisher()
     .publish(dataBuffer, customAttributes);
   console.log(`Message ${messageId} published.`);
 
@@ -162,8 +158,7 @@ async function publishBatchedMessages(
   const dataBuffer = Buffer.from(data);
 
   const [messageId] = await pubsub
-    .topic(topicName)
-    .publisher({
+    .topic(topicName, {
       batching: {
         maxMessages: maxMessages,
         maxMilliseconds: maxWaitTime,
@@ -269,7 +264,6 @@ async function publishOrderedMessage(topicName, data) {
   // Publishes the message
   const messageId = await pubsub
     .topic(topicName)
-    .publisher()
     .publish(dataBuffer, attributes);
   // Update the counter value
   setPublishCounterValue(parseInt(attributes.counterId, 10) + 1);

--- a/src/index.ts
+++ b/src/index.ts
@@ -34,7 +34,7 @@ const v1 = require('./v1');
 
 import {Snapshot} from './snapshot';
 import {Subscription, SubscriptionMetadata, SubscriptionMetadataRaw} from './subscription';
-import {Topic} from './topic';
+import {Topic, PublishOptions} from './topic';
 import {CallOptions} from 'google-gax';
 import {Readable} from 'stream';
 
@@ -848,11 +848,11 @@ export class PubSub {
    *
    * const topic = pubsub.topic('my-topic');
    */
-  topic(name: string) {
+  topic(name: string, options?: PublishOptions): Topic {
     if (!name) {
       throw new Error('A name must be specified for a topic.');
     }
-    return new Topic(this, name);
+    return new Topic(this, name, options);
   }
 }
 
@@ -966,7 +966,7 @@ promisifyAll(PubSub, {
   exclude: ['request', 'snapshot', 'subscription', 'topic'],
 });
 
-export {Subscription, Topic};
+export {Subscription, Topic, PublishOptions};
 
 /**
  * The default export of the `@google-cloud/pubsub` package is the

--- a/src/publisher.ts
+++ b/src/publisher.ts
@@ -61,6 +61,7 @@ export interface PublishOptions {
 /**
  * A Publisher object allows you to publish messages to a specific topic.
  *
+ * @private
  * @class
  *
  * @see [Topics: publish API Documentation]{@link https://cloud.google.com/pubsub/docs/reference/rest/v1/projects.topics/publish}

--- a/src/publisher.ts
+++ b/src/publisher.ts
@@ -90,12 +90,6 @@ export class Publisher {
 
     this.setOptions(options);
 
-    /**
-     * The topic of this publisher.
-     *
-     * @name Publisher#topic
-     * @type {Topic}
-     */
     this.topic = topic;
     // this object keeps track of all messages scheduled to be published
     // queued is essentially the `messages` field for the publish rpc req opts
@@ -108,18 +102,19 @@ export class Publisher {
       bytes: 0,
     };
   }
-
   /**
-   * @typedef {array} PublisherPublishResponse
+   * @typedef {array} PublishResponse
    * @property {string} 0 The id for the message.
    */
   /**
-   * @callback PublisherPublishCallback
+   * @callback PublishCallback
    * @param {?Error} err Request error, if any.
    * @param {string} messageId The id for the message.
    */
   /**
    * Publish the provided message.
+   *
+   * @private
    *
    * @throws {TypeError} If data is not a Buffer object.
    * @throws {TypeError} If any value in `attributes` object is not a string.
@@ -127,8 +122,8 @@ export class Publisher {
    * @param {buffer} data The message data. This must come in the form of a
    *     Buffer object.
    * @param {object.<string, string>} [attributes] Attributes for this message.
-   * @param {PublisherPublishCallback} [callback] Callback function.
-   * @returns {Promise<PublisherPublishResponse>}
+   * @param {PublishCallback} [callback] Callback function.
+   * @returns {Promise<PublishResponse>}
    *
    * @example
    * const {PubSub} = require('@google-cloud/pubsub');
@@ -206,6 +201,8 @@ export class Publisher {
   }
   /**
    * Sets the Publisher options.
+   *
+   * @private
    *
    * @param {PublishOptions} options The publisher options.
    */

--- a/src/topic.ts
+++ b/src/topic.ts
@@ -61,11 +61,6 @@ export class Topic {
      * @type {string}
      */
     this.name = Topic.formatName_(pubsub.projectId, name);
-    /**
-     * The publisher instance of this topic instance.
-     * @name Topic#publisher
-     * @type {Publisher}
-     */
     this.publisher = new Publisher(this, options);
     /**
      * The parent {@link PubSub} instance of this topic instance.

--- a/src/topic.ts
+++ b/src/topic.ts
@@ -483,8 +483,8 @@ export class Topic {
    * @param {buffer} data The message data. This must come in the form of a
    *     Buffer object.
    * @param {object.<string, string>} [attributes] Attributes for this message.
-   * @param {PublisherPublishCallback} [callback] Callback function.
-   * @returns {Promise<PublisherPublishResponse>}
+   * @param {PublishCallback} [callback] Callback function.
+   * @returns {Promise<PublishResponse>}
    *
    * @example
    * const {PubSub} = require('@google-cloud/pubsub');

--- a/src/topic.ts
+++ b/src/topic.ts
@@ -538,13 +538,13 @@ export class Topic {
    *
    * const topic = pubsub.topic('my-topic');
    *
-   * topic.setOptions({
+   * topic.setPublishOptions({
    *   batching: {
    *     maxMilliseconds: 10
    *   }
    * });
    */
-  setOptions(options: PublishOptions): void {
+  setPublishOptions(options: PublishOptions): void {
     this.publisher.setOptions(options);
   }
   /**
@@ -654,7 +654,7 @@ paginator.extend(Topic, ['getSubscriptions']);
  * that a callback is omitted.
  */
 promisifyAll(Topic, {
-  exclude: ['publish', 'setOptions', 'subscription'],
+  exclude: ['publish', 'setPublishOptions', 'subscription'],
 });
 
 export {PublishOptions};

--- a/system-test/pubsub.ts
+++ b/system-test/pubsub.ts
@@ -469,7 +469,7 @@ describe('pubsub', () => {
 
       const subscription = topic.subscription(SUB_NAMES[0]);
 
-      topic.setOptions({batching: {maxMessages: 999}});
+      topic.setPublishOptions({batching: {maxMessages: 999}});
       await publish(MESSAGES);
 
       const startTime = Date.now();

--- a/system-test/pubsub.ts
+++ b/system-test/pubsub.ts
@@ -54,12 +54,11 @@ describe('pubsub', () => {
 
   async function publishPop(message, options = {}) {
     const topic = pubsub.topic(generateTopicName());
-    const publisher = topic.publisher();
     const subscription = topic.subscription(generateSubName());
     await topic.create();
     await subscription.create();
     for (let i = 0; i < 6; i++) {
-      await publisher.publish(Buffer.from(message), options);
+      await topic.publish(Buffer.from(message), options);
     }
     return new Promise((resolve, reject) => {
       subscription.on('error', reject);
@@ -165,10 +164,9 @@ describe('pubsub', () => {
 
     it('should publish a message', done => {
       const topic = pubsub.topic(TOPIC_NAMES[0]);
-      const publisher = topic.publisher();
       const message = Buffer.from('message from me');
 
-      publisher.publish(message, (err, messageId) => {
+      topic.publish(message, (err, messageId) => {
         assert.ifError(err);
         assert.strictEqual(typeof messageId, 'string');
         done();
@@ -199,7 +197,6 @@ describe('pubsub', () => {
   describe('Subscription', () => {
     const TOPIC_NAME = generateTopicName();
     const topic = pubsub.topic(TOPIC_NAME);
-    const publisher = topic.publisher();
 
     const SUB_NAMES = [generateSubName(), generateSubName()];
 
@@ -212,7 +209,7 @@ describe('pubsub', () => {
       await topic.create();
       await Promise.all(SUBSCRIPTIONS.map(s => s.create()));
       for (let i = 0; i < 10; i++) {
-        await publisher.publish(Buffer.from('hello'));
+        await topic.publish(Buffer.from('hello'));
       }
       await new Promise(r => setTimeout(r, 2500));
     });
@@ -470,9 +467,9 @@ describe('pubsub', () => {
 
       this.timeout(0);
 
-      const publisher = topic.publisher({batching: {maxMessages: 999}});
       const subscription = topic.subscription(SUB_NAMES[0]);
 
+      topic.setOptions({batching: {maxMessages: 999}});
       await publish(MESSAGES);
 
       const startTime = Date.now();
@@ -525,7 +522,7 @@ describe('pubsub', () => {
         for (let i = 0; i < messageCount; i++) {
           const testid = String(++id);
           messages.add(testid);
-          promises.push(publisher.publish(data, {testid}));
+          promises.push(topic.publish(data, {testid}));
         }
 
         return Promise.all(promises);
@@ -586,7 +583,6 @@ describe('pubsub', () => {
     const SNAPSHOT_NAME = generateSnapshotName();
 
     let topic;
-    let publisher;
     let subscription;
     let snapshot;
 
@@ -609,7 +605,6 @@ describe('pubsub', () => {
 
     before(() => {
       topic = pubsub.topic(TOPIC_NAMES[0]);
-      publisher = topic.publisher();
       subscription = topic.subscription(generateSubName());
       snapshot = subscription.snapshot(SNAPSHOT_NAME);
 
@@ -661,7 +656,7 @@ describe('pubsub', () => {
 
         return subscription.create()
             .then(() => {
-              return publisher.publish(Buffer.from('Hello, world!'));
+              return topic.publish(Buffer.from('Hello, world!'));
             })
             .then(_messageId => {
               messageId = _messageId;

--- a/test/index.ts
+++ b/test/index.ts
@@ -1318,5 +1318,17 @@ describe('PubSub', () => {
     it('should return a Topic object', () => {
       assert(pubsub.topic('new-topic') instanceof FakeTopic);
     });
+
+    it('should pass the correct args', () => {
+      const fakeName = 'with-options';
+      const fakeOptions = {};
+      const topic = pubsub.topic(fakeName, fakeOptions);
+
+      const [ps, name, options] = topic.calledWith_;
+
+      assert.strictEqual(ps, pubsub);
+      assert.strictEqual(name, fakeName);
+      assert.strictEqual(options, fakeOptions);
+    });
   });
 });

--- a/test/topic.ts
+++ b/test/topic.ts
@@ -28,7 +28,8 @@ const fakePromisify = Object.assign({}, pfy, {
       return;
     }
     promisified = true;
-    assert.deepStrictEqual(options.exclude, ['publisher', 'subscription']);
+    assert.deepStrictEqual(
+        options.exclude, ['publish', 'setOptions', 'subscription']);
   },
 });
 
@@ -45,8 +46,18 @@ class FakePublisher {
   // tslint:disable-next-line no-any
   calledWith_: any[];
   // tslint:disable-next-line no-any
+  published_!: any[];
+  options_!: object;
+  // tslint:disable-next-line no-any
   constructor(...args: any[]) {
     this.calledWith_ = args;
+  }
+  // tslint:disable-next-line no-any
+  publish(...args: any[]) {
+    this.published_ = args;
+  }
+  setOptions(options: object) {
+    this.options_ = options;
   }
 }
 
@@ -134,6 +145,16 @@ describe('Topic', () => {
 
       const topic = new Topic(PUBSUB, TOPIC_NAME);
       assert.strictEqual(topic.name, formattedName);
+    });
+
+    it('should create a publisher', () => {
+      const fakeOptions = {};
+      const topic = new Topic(PUBSUB, TOPIC_NAME, fakeOptions);
+
+      const [t, options] = topic.publisher.calledWith_;
+
+      assert.strictEqual(t, topic);
+      assert.strictEqual(options, fakeOptions);
     });
 
     it('should localize the parent object', () => {
@@ -516,16 +537,31 @@ describe('Topic', () => {
     });
   });
 
-  describe('publisher', () => {
-    it('should return a Publisher instance', () => {
-      const options = {};
+  describe('publish', () => {
+    it('should call through to Publisher#publish', () => {
+      const data = Buffer.from('Hello, world!');
+      const attributes = {};
+      const callback = () => {};
 
-      const publisher = topic.publisher(options);
-      const args = publisher.calledWith_;
+      const fakePromise = Promise.resolve();
+      const stub = sandbox.stub(topic.publisher, 'publish')
+                       .withArgs(data, attributes, callback)
+                       .returns(fakePromise);
 
-      assert(publisher instanceof FakePublisher);
-      assert.strictEqual(args[0], topic);
-      assert.strictEqual(args[1], options);
+      const promise = topic.publish(data, attributes, callback);
+      assert.strictEqual(promise, fakePromise);
+    });
+  });
+
+  describe('setOptions', () => {
+    it('should call through to Publisher#setOptions', () => {
+      const fakeOptions = {};
+      const stub =
+          sandbox.stub(topic.publisher, 'setOptions').withArgs(fakeOptions);
+
+      topic.setOptions(fakeOptions);
+
+      assert.strictEqual(stub.callCount, 1);
     });
   });
 

--- a/test/topic.ts
+++ b/test/topic.ts
@@ -29,7 +29,7 @@ const fakePromisify = Object.assign({}, pfy, {
     }
     promisified = true;
     assert.deepStrictEqual(
-        options.exclude, ['publish', 'setOptions', 'subscription']);
+        options.exclude, ['publish', 'setPublishOptions', 'subscription']);
   },
 });
 
@@ -553,13 +553,13 @@ describe('Topic', () => {
     });
   });
 
-  describe('setOptions', () => {
+  describe('setPublishOptions', () => {
     it('should call through to Publisher#setOptions', () => {
       const fakeOptions = {};
       const stub =
           sandbox.stub(topic.publisher, 'setOptions').withArgs(fakeOptions);
 
-      topic.setOptions(fakeOptions);
+      topic.setPublishOptions(fakeOptions);
 
       assert.strictEqual(stub.callCount, 1);
     });


### PR DESCRIPTION
Fixes #246

- [x] Tests and linter pass
- [x] Code coverage does not decrease (if any source code was changed)
- [x] Appropriate docs were updated (if necessary)

---

### Breaking change ahead!

We're already about to make a semver major release, so I figured we might as well sneak this in if we can.

#### Before

```js
const publisher = topic.publisher();
await publisher.publish(Buffer.from('Hello, world!'));
```

#### After

```js
await topic.publish(Buffer.from('Hello, world!'));
```