### PR TITLE
Return the promises from subscriber instance

### DIFF
--- a/samples/subscriptions.js
+++ b/samples/subscriptions.js
@@ -244,14 +244,14 @@ function listenForMessages(subscriptionName, timeout) {
 
   // Create an event handler to handle messages
   let messageCount = 0;
-  const messageHandler = message => {
+  const messageHandler = async message => {
     console.log(`Received message ${message.id}:`);
     console.log(`\tData: ${message.data}`);
     console.log(`\tAttributes: ${message.attributes}`);
     messageCount += 1;
 
     // "Ack" (acknowledge receipt of) the message
-    message.ack();
+    await message.ack();
   };
 
   // Listen for new messages until timeout is hit
@@ -373,12 +373,12 @@ async function listenForOrderedMessages(subscriptionName, timeout) {
   const subscription = pubsub.subscription(subscriptionName);
 
   // Create an event handler to handle messages
-  const messageHandler = function(message) {
+  const messageHandler = async function(message) {
     // Buffer the message in an object (for later ordering)
     outstandingMessages[message.attributes.counterId] = message;
 
     // "Ack" (acknowledge receipt of) the message
-    message.ack();
+    await message.ack();
   };
 
   // Listen for new messages until timeout is hit

--- a/src/subscriber.ts
+++ b/src/subscriber.ts
@@ -90,11 +90,12 @@ export class Message {
    * Acknowledges the message.
    * @private
    */
-  ack(): void {
+  ack(): Promise<void> {
     if (!this._handled) {
       this._handled = true;
-      this._subscriber.ack(this);
+      return this._subscriber.ack(this);
     }
+    return Promise.resolve();
   }
   /**
    * Modifies the ack deadline.
@@ -102,10 +103,11 @@ export class Message {
    * @param {number} deadline The number of seconds to extend the deadline.
    * @private
    */
-  modAck(deadline: number): void {
+  modAck(deadline: number): Promise<void> {
     if (!this._handled) {
-      this._subscriber.modAck(this, deadline);
+      return this._subscriber.modAck(this, deadline);
     }
+    return Promise.resolve();
   }
   /**
    * Removes the message from our inventory and schedules it to be redelivered.
@@ -115,11 +117,12 @@ export class Message {
    *     redelivery occurs.
    * @private
    */
-  nack(delay?: number): void {
+  nack(delay?: number): Promise<void> {
     if (!this._handled) {
       this._handled = true;
-      this._subscriber.nack(this, delay);
+      return this._subscriber.nack(this, delay);
     }
+    return Promise.resolve();
   }
   /**
    * Formats the protobuf timestamp into a JavaScript date.


### PR DESCRIPTION
- [X] Tests and linter pass
- [X] Code coverage does not decrease (if any source code was changed)
- [X] Appropriate docs were updated (if necessary)

For example, the `ack` method of `Message` class return the subscriber's ack when it is not handled. We should response a promise just like what we get from subscriber's ack.