### PR TITLE
fix(auth): pass project id to gax clients

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -806,6 +806,8 @@ export class PubSub {
           return;
         }
         this.projectId = projectId!;
+        this.options.projectId = projectId!;
+
         this.getClient_(config, callback);
       });
       return;

--- a/test/index.ts
+++ b/test/index.ts
@@ -1084,6 +1084,7 @@ describe('PubSub', () => {
         pubsub.getClient_(CONFIG, err => {
           assert.ifError(err);
           assert.strictEqual(pubsub.projectId, PROJECT_ID);
+          assert.strictEqual(pubsub.options.projectId, PROJECT_ID);
           done();
         });
       });


### PR DESCRIPTION
Fixes #288
Fixes #445
 
- [x] Tests and linter pass
- [x] Code coverage does not decrease (if any source code was changed)
- [x] Appropriate docs were updated (if necessary)

---

Looks like not passing the project ID into the gapic clients causes a bunch of future `getProjectId` calls which makes CPU usage spike pretty high

```sh
 [Summary]:
   ticks  total  nonlib   name
   3380   67.2%   71.3%  JavaScript

 [Bottom up (heavy) profile]:
   ticks parent  name
    922   18.3%  LazyCompile: *auth.getProjectId /Users/taco/projects/temp/node_modules/@google-cloud/pubsub/build/src/index.js:599:36
    921   99.9%    LazyCompile: *getProjectIdAsync.then.r /Users/taco/projects/temp/node_modules/google-auth-library/build/src/auth/googleauth.js:73:43
    921  100.0%      T node::RunMicrotasks(v8::FunctionCallbackInfo<v8::Value> const&)
    921  100.0%        LazyCompile: ~_tickCallback internal/process/next_tick.js:41:25
```