### PR TITLE
fix: fix broken snapshot test hook

### DIFF
--- a/system-test/pubsub.ts
+++ b/system-test/pubsub.ts
@@ -597,29 +597,20 @@ describe('pubsub', () => {
       });
     }
 
-    function wait(milliseconds) {
-      return () => {
-        return new Promise(resolve => {
-          setTimeout(resolve, milliseconds);
-        });
-      };
-    }
-
-    before(() => {
-      topic = pubsub.topic(TOPIC_NAMES[0]);
+    before(async () => {
+      topic = pubsub.topic(generateTopicName());
       subscription = topic.subscription(generateSubName());
       snapshot = subscription.snapshot(SNAPSHOT_NAME);
 
-      return deleteAllSnapshots()
-          .then(wait(2500))
-          .then(subscription.create.bind(subscription))
-          .then(wait(2500))
-          .then(snapshot.create.bind(snapshot))
-          .then(wait(2500));
+      await deleteAllSnapshots();
+      await topic.create();
+      await subscription.create();
+      await snapshot.create();
     });
 
-    after(() => {
-      return deleteAllSnapshots();
+    after(async () => {
+      await deleteAllSnapshots();
+      await topic.delete();
     });
 
     it('should get a list of snapshots', done => {


### PR DESCRIPTION
I'm not entirely sure why, but [publishing a message](https://github.com/googleapis/nodejs-pubsub/blob/master/system-test/pubsub.ts#L169) to a specific topic then re-using the same topic to create a Snapshot fails. I updated the Snapshot hooks to create/delete a dedicated Topic and it seems to have resolved the issue.