### PR TITLE
fix(sample): fix retry codes in retry sample code

### DIFF
--- a/samples/topics.js
+++ b/samples/topics.js
@@ -204,13 +204,13 @@ async function publishWithRetrySettings(projectId, topicName, data) {
   // Default values are shown
   const retrySettings = {
     retryCodes: [
-      'ABORTED',
-      'CANCELLED',
-      'DEADLINE_EXCEEDED',
-      'INTERNAL',
-      'RESOURCE_EXHAUSTED',
-      'UNAVAILABLE',
-      'UNKNOWN',
+      10, // 'ABORTED'
+      1, // 'CANCELLED',
+      4, // 'DEADLINE_EXCEEDED'
+      13, // 'INTERNAL'
+      8, // 'RESOURCE_EXHAUSTED'
+      14, // 'UNAVAILABLE'
+      2, // 'UNKNOWN'
     ],
     backoffSettings: {
       initialRetryDelayMillis: 100,


### PR DESCRIPTION
Fixes retry codes in sample code.
These were updated in #419, but it looks like both the previous and the updated values are wrong, gax expects retry codes as numbers. 
The documentation for gax-nodejs also looks flawed (http://googleapis.github.io/gax-nodejs/global.html#RetryOptions), I've opened a PR to update the docs there to.

It takes a bit of time to figure out how to actually set up custom retry for pubsub, it would be a bit easier if the sample codes are updated.

- [ ] Tests and linter pass
- [ ] Code coverage does not decrease (if any source code was changed)
- [ ] Appropriate docs were updated (if necessary)
