### PR TITLE
test: make smoke test spam less

### DIFF
--- a/smoke-test/publisher_smoke_test.js
+++ b/smoke-test/publisher_smoke_test.js
@@ -83,12 +83,16 @@ describe('PublisherSmokeTest', () => {
     });
 
     const formattedProject = client.projectPath(projectId);
+    let counter = 0;
     client
       .listTopicsStream({project: formattedProject})
       .on('data', element => {
-        console.log(element);
+        ++counter;
       })
       .on('error', done)
-      .on('end', done);
+      .on('end', () => {
+        console.log(`${counter} elements received.`);
+        done();
+      });
   });
 });

--- a/smoke-test/publisher_smoke_test.js
+++ b/smoke-test/publisher_smoke_test.js
@@ -86,7 +86,7 @@ describe('PublisherSmokeTest', () => {
     let counter = 0;
     client
       .listTopicsStream({project: formattedProject})
-      .on('data', element => {
+      .on('data', () => {
         ++counter;
       })
       .on('error', done)


### PR DESCRIPTION
If we had charged tests for using lines of stdout, this one would've gone bankrupt soon.
(I use this in gax system tests and hate it when I need to scroll down tons of lines this test prints)

- [x] Tests and linter pass (well, I hope so)
- [x] Code coverage does not decrease (if any source code was changed)
- [x] Appropriate docs were updated (if necessary)
