### PR TITLE
test: fix publishTime issues

### DIFF
--- a/samples/system-test/topics.test.js
+++ b/samples/system-test/topics.test.js
@@ -155,7 +155,7 @@ describe('topics', () => {
   });
 
   it('should publish with specific batch settings', async () => {
-    const waitTime = 1000;
+    const waitTime = 5000;
     const [subscription] = await pubsub
       .topic(topicNameOne)
       .subscription(subscriptionNameThree)
@@ -169,10 +169,11 @@ describe('topics', () => {
     const receivedMessage = await _pullOneMessage(subscription);
 
     const publishTime = Date.parse(receivedMessage.publishTime);
+    // publishTime contains whole seconds (ends with 000), 
+    // so we allow the difference to be up to 1 second less 
+    // than we expect.
     const actualWait = publishTime - startTime;
-    // setTimeout isn't so reliable to publish messages EXACTLY at 1000ms,
-    // so we should consider anything above 900 as passing.
-    const expectedWait = waitTime - 100;
+    const expectedWait = waitTime - 1000;
 
     assert.strictEqual(receivedMessage.data.toString(), expectedMessage.data);
     assert(actualWait >= expectedWait);

--- a/samples/system-test/topics.test.js
+++ b/samples/system-test/topics.test.js
@@ -169,8 +169,8 @@ describe('topics', () => {
     const receivedMessage = await _pullOneMessage(subscription);
 
     const publishTime = Date.parse(receivedMessage.publishTime);
-    // publishTime contains whole seconds (ends with 000), 
-    // so we allow the difference to be up to 1 second less 
+    // publishTime contains whole seconds (ends with 000),
+    // so we allow the difference to be up to 1 second less
     // than we expect.
     const actualWait = publishTime - startTime;
     const expectedWait = waitTime - 1000;


### PR DESCRIPTION
This PR fixes sample test `should publish with specific batch settings` (based on the discussion in #491). I was debugging totally different stuff but realized you're talking about something very interesting and could not resist from debugging this test as well. Good news by the way: sample tests work perfectly with `grpc-js`. Just wanted to let you folks know :)

I added all possible logging to the test (#493 shows my test runs) and found some interesting things that I'd like to share with you folks.

1. `setTimeout` is very accurate. Only once in all my tests it fired 1 ms earlier than needed, and I guess it's more like a time precision problem than the actual early run.

2. The test failure is caused by the sad fact that `publishTime` returned by Pub/Sub is always a _whole second_. Since the test expects millisecond precision, it fails quite often and randomly.

The easiest way to fix a test is to allow up to 1 second offset (accounting for the lost millisecond portion).

See some pictures from my test runs. The first line (`ts=`) is the actual timestamp (logged in `publish_`), the line with `publishTime:` shows the time returned in the message. Note that all `publishTime` timestamps end with `000`.

The `[p] diff` line shows the actual measured sleep time of `setTimeout`. You can see it's correct in both pass and fail test runs.

Fails:

![image](https://user-images.githubusercontent.com/4015807/53236817-0e7c0780-364a-11e9-8809-e7b9e84f0475.png)

![image](https://user-images.githubusercontent.com/4015807/53236834-1b006000-364a-11e9-86e1-05d544bad504.png)

Passes:

![image](https://user-images.githubusercontent.com/4015807/53236855-294e7c00-364a-11e9-9580-46c817c2bc68.png)

![image](https://user-images.githubusercontent.com/4015807/53236874-33707a80-364a-11e9-8d73-96b1e79258d8.png)

- [x] Tests and linter pass
- [x] Code coverage does not decrease (if any source code was changed)
- [x] Appropriate docs were updated (if necessary)
