### PR TITLE
test(samples): correctly handle publishTime value

### DIFF
--- a/samples/system-test/subscriptions.test.js
+++ b/samples/system-test/subscriptions.test.js
@@ -20,7 +20,11 @@ const {assert} = require('chai');
 const execa = require('execa');
 const uuid = require('uuid');
 
-const exec = async cmd => (await execa.shell(cmd)).stdout;
+async function exec(cmd) {
+  const promise = execa.shell(cmd);
+  promise.stdout.pipe(process.stdout);
+  return (await promise).stdout;
+}
 
 describe('subscriptions', () => {
   const projectId = process.env.GCLOUD_PROJECT;


### PR DESCRIPTION
Re: https://github.com/googleapis/nodejs-pubsub/pull/494#issuecomment-466521584

Today I learned that passing a `Date` object to `Date.parse` rounds off milliseconds. I'm guessing we did this because the REST API returns an ISO string and it probably was overlooked when converting to grpc.

Additionally I made a small edit to the `exec` function to make debugging Samples a little less painful.

- [x] Tests and linter pass
- [x] Code coverage does not decrease (if any source code was changed)
- [x] Appropriate docs were updated (if necessary)

