### PR TITLE
fix(docs): ensure docs are not removed by typescript

### DIFF
--- a/src/iam.ts
+++ b/src/iam.ts
@@ -23,7 +23,6 @@ import * as arrify from 'arrify';
 import {CallOptions} from 'google-gax';
 import {PubSub} from '.';
 
-
 export interface GetPolicyCallback {
   (err?: Error|null, acl?: Policy|null): void;
 }

--- a/src/iam.ts
+++ b/src/iam.ts
@@ -23,45 +23,21 @@ import * as arrify from 'arrify';
 import {CallOptions} from 'google-gax';
 import {PubSub} from '.';
 
-/**
- * @callback GetPolicyCallback
- * @param {?Error} err Request error, if any.
- * @param {object} acl The policy.
- */
+
 export interface GetPolicyCallback {
   (err?: Error|null, acl?: Policy|null): void;
 }
 
-/**
- * @callback SetPolicyCallback
- * @param {?Error} err Request error, if any.
- * @param {object} acl The policy.
- */
 export interface SetPolicyCallback {
   (err?: Error|null, acl?: Policy|null): void;
 }
 
-/**
- * @typedef {array} SetPolicyResponse
- * @property {object} 0 The policy.
- */
 export type SetPolicyResponse = [Policy];
-
-/**
- * @typedef {array} GetPolicyResponse
- * @property {object} 0 The policy.
- */
 export type GetPolicyResponse = [Policy];
 
-/**
- * @typedef {string[]} PermissionsResponse
- * A subset of TestPermissionsRequest.permissions that the caller is allowed.
- * @see https://cloud.google.com/pubsub/docs/reference/rpc/google.iam.v1#google.iam.v1.TestIamPermissionsRequest
- */
 export interface PermissionsResponse {
   permissions: string|string[];
 }
-
 
 /**
  * Shows which IAM permissions is allowed.
@@ -72,19 +48,8 @@ export type IamPermissionsMap = {
   [key: string]: boolean
 };
 
-/**
- * @typedef {array} TestIamPermissionsResponse
- * @property {object[]} 0 A subset of permissions that the caller is allowed.
- * @property {PermissionsResponse} 1 The full API response.
- */
 export type TestIamPermissionsResponse = [PermissionsResponse];
 
-/**
- * @callback TestIamPermissionsCallback
- * @param {?Error} err Request error, if any.
- * @param {TestIamPermissionsAPIResponse} permissions A subset of permissions that the caller is allowed.
- * @param {PermissionsResponse} apiResponse The full API response.
- */
 export interface TestIamPermissionsCallback {
   (err?: Error|null, permissions?: IamPermissionsMap|null,
    apiResponse?: PermissionsResponse): void;
@@ -180,6 +145,15 @@ export class IAM {
   getPolicy(callback: GetPolicyCallback): void;
   getPolicy(gaxOpts: CallOptions, callback: GetPolicyCallback): void;
   /**
+   * @typedef {array} GetPolicyResponse
+   * @property {object} 0 The policy.
+   */
+  /**
+   * @callback GetPolicyCallback
+   * @param {?Error} err Request error, if any.
+   * @param {object} acl The policy.
+   */
+  /**
    * Get the IAM policy
    *
    * @param {object} [gaxOptions] Request configuration options, outlined
@@ -235,6 +209,15 @@ export class IAM {
   setPolicy(policy: Policy, gaxOpts: CallOptions, callback: SetPolicyCallback):
       void;
   setPolicy(policy: Policy, callback: SetPolicyCallback): void;
+  /**
+   * @typedef {array} SetPolicyResponse
+   * @property {object} 0 The policy.
+   */
+  /**
+   * @callback SetPolicyCallback
+   * @param {?Error} err Request error, if any.
+   * @param {object} acl The policy.
+   */
   /**
    * Set the IAM policy
    *
@@ -317,6 +300,22 @@ export class IAM {
       callback: TestIamPermissionsCallback): void;
   testPermissions(
       permissions: string|string[], callback: TestIamPermissionsCallback): void;
+  /**
+   * @callback TestIamPermissionsCallback
+   * @param {?Error} err Request error, if any.
+   * @param {TestIamPermissionsAPIResponse} permissions A subset of permissions that the caller is allowed.
+   * @param {PermissionsResponse} apiResponse The full API response.
+   */
+  /**
+   * @typedef {array} TestIamPermissionsResponse
+   * @property {object[]} 0 A subset of permissions that the caller is allowed.
+   * @property {PermissionsResponse} 1 The full API response.
+   */
+  /**
+   * @typedef {string[]} PermissionsResponse
+   * A subset of TestPermissionsRequest.permissions that the caller is allowed.
+   * @see https://cloud.google.com/pubsub/docs/reference/rpc/google.iam.v1#google.iam.v1.TestIamPermissionsRequest
+   */
   /**
    * Test a set of permissions for a resource.
    *

--- a/src/index.ts
+++ b/src/index.ts
@@ -109,7 +109,6 @@ export interface Attributes {
   [key: string]: string;
 }
 
-
 export interface SubscriptionCallOptions {
   flowControl?: FlowControlOptions;
   maxConnections?: number;
@@ -120,24 +119,11 @@ export interface SubscriptionCallOptions {
   batching?: BatchPublishOptions;
 }
 
-
-
-/**
- * @callback CreateSnapshotCallback
- * @param {?Error} err Request error, if any.
- * @param {Snapshot} snapshot
- * @param {object} apiResponse The full API response.
- */
 export interface CreateSnapshotCallback {
   (err: Error|null, snapshot?: Snapshot|null,
    apiResponse?: google.pubsub.v1.ISnapshot): void;
 }
 
-/**
- * @typedef {array} CreateSnapshotResponse
- * @property {Snapshot}.
- * @property {object} 1 The full API response.
- */
 export type CreateSnapshotResponse = [Snapshot, google.pubsub.v1.ISnapshot];
 
 /**
@@ -150,30 +136,13 @@ const PROJECT_ID_PLACEHOLDER = '{{projectId}}';
 // tslint:disable-next-line:no-any
 export type Metadata = any;
 
-/**
- * @typedef {array} CreateTopicResponse
- * @property {Topic} 0 The new {@link Topic}.
- * @property {object} 1 The full API response.
- */
 export type CreateTopicResponse = [Topic, google.pubsub.v1.ITopic];
 
-/**
- * @callback CreateTopicCallback
- * @param {?Error} err Request error, if any.
- * @param {Topic} topic The new {@link Topic}.
- * @param {object} apiResponse The full API response.
- */
 export interface CreateTopicCallback {
   (err?: Error|null, topic?: Topic|null,
    apiResponse?: google.pubsub.v1.ITopic): void;
 }
 
-/**
- * @callback CreateSubscriptionCallback
- * @param {?Error} err Request error, if any.
- * @param {Subscription} Subscription
- * @param {object} apiResponse The full API response.
- */
 export interface CreateSubscriptionCallback {
   (err?: Error|null, subscription?: Subscription|null,
    apiResponse?: google.pubsub.v1.ISubscription): void;
@@ -197,11 +166,6 @@ export interface RequestCallback<TResponse> {
   (err?: Error|null, res?: TResponse|null): void;
 }
 
-/**
- * @typedef {array} CreateSubscriptionResponse
- * @property {Subscription} 0 The new {@link Subscription}.
- * @property {object} 1 The full API response.
- */
 export type CreateSubscriptionResponse =
     [Subscription, google.pubsub.v1.ISubscription];
 
@@ -346,6 +310,17 @@ export class PubSub {
       topic: Topic|string, name: string,
       callback: CreateSubscriptionCallback): void;
   /**
+   * @typedef {array} CreateSubscriptionResponse
+   * @property {Subscription} 0 The new {@link Subscription}.
+   * @property {object} 1 The full API response.
+   */
+  /**
+   * @callback CreateSubscriptionCallback
+   * @param {?Error} err Request error, if any.
+   * @param {Subscription} Subscription
+   * @param {object} apiResponse The full API response.
+   */
+  /**
    * Options for creating a subscription.
    *
    * See a [Subscription
@@ -470,6 +445,17 @@ export class PubSub {
   createTopic(
       name: string, gaxOpts: CallOptions, callback?: CreateTopicCallback): void;
   createTopic(name: string, callback: CreateTopicCallback): void;
+  /**
+   * @typedef {array} CreateTopicResponse
+   * @property {Topic} 0 The new {@link Topic}.
+   * @property {object} 1 The full API response.
+   */
+  /**
+   * @callback CreateTopicCallback
+   * @param {?Error} err Request error, if any.
+   * @param {Topic} topic The new {@link Topic}.
+   * @param {object} apiResponse The full API response.
+   */
   /**
    * Create a topic with the given name.
    *

--- a/src/snapshot.ts
+++ b/src/snapshot.ts
@@ -101,6 +101,8 @@ export class Snapshot {
     this.name = Snapshot.formatName_(parent.projectId, name);
   }
 
+  delete(): Promise<google.protobuf.Empty>;
+  delete(callback: RequestCallback<google.protobuf.Empty>): void;
   /**
    * Delete the snapshot.
    *
@@ -120,8 +122,6 @@ export class Snapshot {
    *   const apiResponse = data[0];
    * });
    */
-  delete(): Promise<google.protobuf.Empty>;
-  delete(callback: RequestCallback<google.protobuf.Empty>): void;
   delete(callback?: RequestCallback<google.protobuf.Empty>):
       void|Promise<google.protobuf.Empty> {
     const reqOpts = {
@@ -136,6 +136,7 @@ export class Snapshot {
         },
         callback);
   }
+
   /*@
    * Format the name of a snapshot. A snapshot's full name is in the format of
    * projects/{projectId}/snapshots/{snapshotName}
@@ -146,6 +147,9 @@ export class Snapshot {
     return 'projects/' + projectId + '/snapshots/' + name.split('/').pop();
   }
 
+  create(gaxOpts?: CallOptions): Promise<CreateSnapshotResponse>;
+  create(callback: CreateSnapshotCallback): void;
+  create(gaxOpts: CallOptions, callback: CreateSnapshotCallback): void;
   /**
    * Create a snapshot with the given name.
    *
@@ -181,9 +185,6 @@ export class Snapshot {
    *   const apiResponse = data[1];
    * });
    */
-  create(gaxOpts?: CallOptions): Promise<CreateSnapshotResponse>;
-  create(callback: CreateSnapshotCallback): void;
-  create(gaxOpts: CallOptions, callback: CreateSnapshotCallback): void;
   create(
       gaxOpts?: CallOptions|CreateSnapshotCallback,
       callback?: CreateSnapshotCallback): void|Promise<CreateSnapshotResponse> {
@@ -195,6 +196,9 @@ export class Snapshot {
         .createSnapshot(this.name, gaxOpts! as CallOptions, callback!);
   }
 
+  seek(gaxOpts?: CallOptions): Promise<google.pubsub.v1.ISeekResponse>;
+  seek(callback: SeekCallback): void;
+  seek(gaxOpts: CallOptions, callback: SeekCallback): void;
   /**
    * Seeks an existing subscription to the snapshot.
    *
@@ -220,9 +224,6 @@ export class Snapshot {
    *   const apiResponse = data[0];
    * });
    */
-  seek(gaxOpts?: CallOptions): Promise<google.pubsub.v1.ISeekResponse>;
-  seek(callback: SeekCallback): void;
-  seek(gaxOpts: CallOptions, callback: SeekCallback): void;
   seek(gaxOpts?: CallOptions|SeekCallback, callback?: SeekCallback):
       void|Promise<google.pubsub.v1.ISeekResponse> {
     if (!(this.parent instanceof Subscription)) {

--- a/src/topic.ts
+++ b/src/topic.ts
@@ -121,6 +121,10 @@ export class Topic {
      */
     this.iam = new IAM(pubsub, this.name);
   }
+
+  create(gaxOpts?: CallOptions): Promise<CreateTopicResponse>;
+  create(callback: CreateTopicCallback): void;
+  create(gaxOpts: CallOptions, callback: CreateTopicCallback): void;
   /**
    * Create a topic.
    *
@@ -149,9 +153,6 @@ export class Topic {
    *   const apiResponse = data[1];
    * });
    */
-  create(gaxOpts?: CallOptions): Promise<CreateTopicResponse>;
-  create(callback: CreateTopicCallback): void;
-  create(gaxOpts: CallOptions, callback: CreateTopicCallback): void;
   create(
       gaxOptsOrCallback?: CallOptions|CreateTopicCallback,
       callback?: CreateTopicCallback): Promise<CreateTopicResponse>|void {
@@ -162,6 +163,13 @@ export class Topic {
 
     this.pubsub.createTopic(this.name, gaxOpts, callback);
   }
+
+  createSubscription(name: string, callback: CreateSubscriptionCallback): void;
+  createSubscription(name: string, options?: CreateSubscriptionOptions):
+      Promise<CreateSubscriptionResponse>;
+  createSubscription(
+      name: string, options: CreateSubscriptionOptions,
+      callback: CreateSubscriptionCallback): void;
   /**
    * Create a subscription to this topic.
    *
@@ -199,12 +207,6 @@ export class Topic {
    *   const apiResponse = data[1];
    * });
    */
-  createSubscription(name: string, callback: CreateSubscriptionCallback): void;
-  createSubscription(name: string, options?: CreateSubscriptionOptions):
-      Promise<CreateSubscriptionResponse>;
-  createSubscription(
-      name: string, options: CreateSubscriptionOptions,
-      callback: CreateSubscriptionCallback): void;
   createSubscription(
       name: string,
       optionsOrCallback?: CreateSubscriptionOptions|CreateSubscriptionCallback,
@@ -218,6 +220,12 @@ export class Topic {
     this.pubsub.createSubscription(
         this, name, options as CreateSubscriptionOptions, callback!);
   }
+
+  delete(callback: RequestCallback<google.protobuf.Empty>): void;
+  delete(gaxOpts?: CallOptions): Promise<google.protobuf.Empty>;
+  delete(
+      gaxOpts: CallOptions,
+      callback: RequestCallback<google.protobuf.Empty>): void;
   /**
    * Delete the topic. This will not delete subscriptions to this topic.
    *
@@ -245,11 +253,6 @@ export class Topic {
    *   const apiResponse = data[0];
    * });
    */
-  delete(callback: RequestCallback<google.protobuf.Empty>): void;
-  delete(gaxOpts?: CallOptions): Promise<google.protobuf.Empty>;
-  delete(
-      gaxOpts: CallOptions,
-      callback: RequestCallback<google.protobuf.Empty>): void;
   delete(
       gaxOptsOrCallback?: CallOptions|RequestCallback<google.protobuf.Empty>,
       callback?: RequestCallback<google.protobuf.Empty>):
@@ -272,6 +275,7 @@ export class Topic {
         },
         callback);
   }
+
   /**
    * @typedef {array} TopicExistsResponse
    * @property {boolean} 0 Whether the topic exists
@@ -321,6 +325,10 @@ export class Topic {
       callback(err);
     });
   }
+
+  get(callback: CreateTopicCallback): void;
+  get(gaxOpts?: GetCallOptions): Promise<Topic>;
+  get(gaxOpts: GetCallOptions, callback: CreateTopicCallback): void;
   /**
    * @typedef {array} GetTopicResponse
    * @property {Topic} 0 The {@link Topic}.
@@ -360,9 +368,6 @@ export class Topic {
    *   const apiResponse = data[1];
    * });
    */
-  get(callback: CreateTopicCallback): void;
-  get(gaxOpts?: GetCallOptions): Promise<Topic>;
-  get(gaxOpts: GetCallOptions, callback: CreateTopicCallback): void;
   get(gaxOptsOrCallback?: GetCallOptions|CreateTopicCallback,
       callback?: CreateTopicCallback): void|Promise<Topic> {
     const gaxOpts =
@@ -389,6 +394,10 @@ export class Topic {
       this.create(gaxOpts, callback!);
     });
   }
+
+  getMetadata(callback: GetTopicMetadataCallback): void;
+  getMetadata(gaxOpts: CallOptions, callback: GetTopicMetadataCallback): void;
+  getMetadata(gaxOpts?: CallOptions): Promise<google.pubsub.v1.ITopic>;
   /**
    * @typedef {array} GetTopicMetadataResponse
    * @property {object} 0 The full API response.
@@ -423,9 +432,6 @@ export class Topic {
    *   const apiResponse = data[0];
    * });
    */
-  getMetadata(callback: GetTopicMetadataCallback): void;
-  getMetadata(gaxOpts: CallOptions, callback: GetTopicMetadataCallback): void;
-  getMetadata(gaxOpts?: CallOptions): Promise<google.pubsub.v1.ITopic>;
   getMetadata(
       gaxOptsOrCallback?: CallOptions|GetTopicMetadataCallback,
       callback?: GetTopicMetadataCallback):
@@ -451,6 +457,14 @@ export class Topic {
           callback!(err, apiResponse);
         });
   }
+
+  getSubscriptions(callback: RequestCallback<Subscription[]>): void;
+  getSubscriptions(
+      options: SubscriptionCallOptions,
+      callback: RequestCallback<Subscription[]>): void;
+  getSubscriptions(
+      options?: SubscriptionCallOptions,
+      ): Promise<Subscription[]>;
   /**
    * Get a list of the subscriptions registered to this topic. You may
    * optionally provide a query object as the first argument to customize the
@@ -487,13 +501,6 @@ export class Topic {
    *   const subscriptions = data[0];
    * });
    */
-  getSubscriptions(callback: RequestCallback<Subscription[]>): void;
-  getSubscriptions(
-      options: SubscriptionCallOptions,
-      callback: RequestCallback<Subscription[]>): void;
-  getSubscriptions(
-      options?: SubscriptionCallOptions,
-      ): Promise<Subscription[]>;
   getSubscriptions(
       optionsOrCallback?: SubscriptionCallOptions|
       RequestCallback<Subscription[]>,
@@ -536,6 +543,11 @@ export class Topic {
           callback!(...args);
         });
   }
+
+  publish(data: Buffer, attributes?: Attributes): Promise<string>;
+  publish(data: Buffer, callback: PublishCallback): void;
+  publish(data: Buffer, attributes: Attributes, callback: PublishCallback):
+      void;
   /**
    * Publish the provided message.
    *
@@ -578,10 +590,6 @@ export class Topic {
    * //-
    * topic.publish(data).then((messageId) => {});
    */
-  publish(data: Buffer, attributes?: Attributes): Promise<string>;
-  publish(data: Buffer, callback: PublishCallback): void;
-  publish(data: Buffer, attributes: Attributes, callback: PublishCallback):
-      void;
   publish(
       data: Buffer, attributesOrCallback?: Attributes|PublishCallback,
       callback?: PublishCallback): Promise<string>|void {
@@ -592,6 +600,11 @@ export class Topic {
         callback;
     return this.publisher.publish(data, attributes, callback!);
   }
+
+  publishJSON(json: object, attributes?: Attributes): Promise<string>;
+  publishJSON(json: object, callback: PublishCallback): void;
+  publishJSON(json: object, attributes: Attributes, callback: PublishCallback):
+      void;
   /**
    * Publish the provided JSON. It should be noted that all messages published
    * are done so in the form of a Buffer. This is simply a convenience method
@@ -640,10 +653,6 @@ export class Topic {
    * //-
    * topic.publishJSON(data).then((messageId) => {});
    */
-  publishJSON(json: object, attributes?: Attributes): Promise<string>;
-  publishJSON(json: object, callback: PublishCallback): void;
-  publishJSON(json: object, attributes: Attributes, callback: PublishCallback):
-      void;
   publishJSON(
       json: object, attributesOrCallback?: Attributes|PublishCallback,
       callback?: PublishCallback): Promise<string>|void {
@@ -659,6 +668,7 @@ export class Topic {
     const data = Buffer.from(JSON.stringify(json));
     return this.publish(data, attributes, callback!);
   }
+
   /**
    * Set the publisher options.
    *
@@ -679,6 +689,7 @@ export class Topic {
   setPublishOptions(options: PublishOptions): void {
     this.publisher.setOptions(options);
   }
+
   /**
    * Create a Subscription object. This command by itself will not run any API
    * requests. You will receive a {module:pubsub/subscription} object,
@@ -723,6 +734,7 @@ export class Topic {
     options.topic = this;
     return this.pubsub.subscription(name, options);
   }
+
   /**
    * Format the name of a topic. A Topic's full name is in the format of
    * 'projects/{projectId}/topics/{topicName}'.


### PR DESCRIPTION
TypeScript removes any docs it finds above interfaces/overloads/etc. This PR moves any typedefs to the corresponding method and places overloads above method docs.