### PR TITLE
fix: update TS types for `PubSub#subscription` to match 0.23+'s API

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -33,6 +33,7 @@ const PKG = require('../../package.json');
 const v1 = require('./v1');
 
 import {Snapshot} from './snapshot';
+import {SubscriberOptions} from './subscriber';
 import {Subscription, SubscriptionMetadataRaw} from './subscription';
 import {Topic, PublishOptions} from './topic';
 import {CallOptions} from 'google-gax';
@@ -109,14 +110,8 @@ export interface Attributes {
   [key: string]: string;
 }
 
-export interface SubscriptionCallOptions {
-  flowControl?: FlowControlOptions;
-  maxConnections?: number;
+export interface SubscriptionCallOptions extends SubscriberOptions {
   topic?: Topic;
-  ackDeadline?: number;
-  autoPaginate?: boolean;
-  gaxOpts?: CallOptions;
-  batching?: BatchPublishOptions;
 }
 
 export interface CreateSnapshotCallback {
@@ -928,7 +923,7 @@ export class PubSub {
    * @throws {Error} If subscription name is omitted.
    *
    * @param {string} name Name of the subscription.
-   * @param {SubscriberOptions} [options] Subscription options.
+   * @param {SubscriptionCallOptions} [options] Subscription options.
    * @returns {Subscription} A {@link Subscription} instance.
    *
    * @example

--- a/src/subscriber.ts
+++ b/src/subscriber.ts
@@ -232,7 +232,7 @@ export class Subscriber extends EventEmitter {
   private _options!: SubscriberOptions;
   private _stream!: MessageStream;
   private _subscription: Subscription;
-  constructor(subscription: Subscription, options = {}) {
+  constructor(subscription: Subscription, options: SubscriberOptions = {}) {
     super();
 
     this.ackDeadline = 10;

--- a/src/subscription.ts
+++ b/src/subscription.ts
@@ -247,7 +247,7 @@ export class Subscription extends EventEmitter {
      */
     this.iam = new IAM(pubsub, this.name);
 
-    this._subscriber = new Subscriber(this, options as SubscriberOptions);
+    this._subscriber = new Subscriber(this, options);
     this._subscriber.on('error', err => this.emit('error', err))
         .on('message', message => this.emit('message', message))
         .on('close', () => this.emit('close'));

--- a/src/topic.ts
+++ b/src/topic.ts
@@ -22,11 +22,12 @@ import {Readable} from 'stream';
 
 import {google} from '../proto/pubsub';
 
-import {Attributes, CreateSubscriptionCallback, CreateSubscriptionOptions, CreateSubscriptionResponse, CreateTopicCallback, CreateTopicResponse, ExistsCallback, GetCallOptions, GetTopicMetadataCallback, Metadata, PubSub, RequestCallback, SubscriptionCallOptions} from '.';
+import {Attributes, CreateSubscriptionCallback, CreateSubscriptionOptions, CreateSubscriptionResponse, CreateTopicCallback, CreateTopicResponse, ExistsCallback, GetCallOptions, GetTopicMetadataCallback, GetSubscriptionsOptions, Metadata, PubSub, RequestCallback, } from '.';
 import {IAM} from './iam';
 import {PublishCallback, Publisher, PublishOptions} from './publisher';
 import {Subscription} from './subscription';
 import * as util from './util';
+import { SubscriberOptions } from './subscriber';
 
 /**
  * A Topic object allows you to interact with a Cloud Pub/Sub topic.
@@ -460,10 +461,10 @@ export class Topic {
 
   getSubscriptions(callback: RequestCallback<Subscription[]>): void;
   getSubscriptions(
-      options: SubscriptionCallOptions,
+      options: GetSubscriptionsOptions,
       callback: RequestCallback<Subscription[]>): void;
   getSubscriptions(
-      options?: SubscriptionCallOptions,
+      options?: GetSubscriptionsOptions,
       ): Promise<Subscription[]>;
   /**
    * Get a list of the subscriptions registered to this topic. You may
@@ -502,7 +503,7 @@ export class Topic {
    * });
    */
   getSubscriptions(
-      optionsOrCallback?: SubscriptionCallOptions|
+      optionsOrCallback?: GetSubscriptionsOptions|
       RequestCallback<Subscription[]>,
       callback?: RequestCallback<Subscription[]>):
       void|Promise<Subscription[]> {
@@ -516,7 +517,7 @@ export class Topic {
         {
           topic: this.name,
         },
-        options as SubscriptionCallOptions);
+        options);
     delete reqOpts.gaxOpts;
     delete reqOpts.autoPaginate;
     const gaxOpts = Object.assign(
@@ -708,8 +709,8 @@ export class Topic {
    * @param {number} [options.flowControl.maxMessages=Infinity] The maximum number
    *     of un-acked messages to allow before the subscription pauses incoming
    *     messages.
-   * @param {number} [options.maxConnections=5] Use this to limit the number of
-   *     connections to be used when sending and receiving messages.
+   * @param {number} [options.streamingOptions.maxStreams=5] Use this to limit the
+   *     number of connections to be used when sending and receiving messages.
    * @return {Subscription}
    *
    * @example
@@ -729,10 +730,15 @@ export class Topic {
    *   // message.publishTime = Timestamp when Pub/Sub received the message.
    * });
    */
-  subscription(name: string, options?: SubscriptionCallOptions): Subscription {
-    options = options || {};
-    options.topic = this;
-    return this.pubsub.subscription(name, options);
+  subscription(name: string, options: SubscriberOptions = {}): Subscription {
+    const subscriptionOptions = Object.assign(
+      {},
+      options,
+      {
+        topic: this,
+      },
+    );
+    return this.pubsub.subscription(name, subscriptionOptions);
   }
 
   /**

--- a/test/topic.ts
+++ b/test/topic.ts
@@ -637,7 +637,9 @@ describe('Topic', () => {
       topic.parent.subscription =
           (name: string, options: SubscriptionCallOptions) => {
             assert.strictEqual(name, subscriptionName);
-            assert.deepStrictEqual(options, opts);
+            for (const key of Object.keys(opts)) {
+              assert.deepStrictEqual(options[key], opts[key]);
+            }
             done();
           };
 


### PR DESCRIPTION
As of 0.23 and later, `PubSub#subscription` and `Topic#subscription` take an options object with `streamingOptions` instead of `maxConnections`. Also, the methods that take this options object never use `gaxOpts` nor `autoPaginate` -- these fields are unused in these code paths.

This commit updates the TS types so that the options object passed to `PubSub#subscription` and `Topic#subscription` (a) has the new `streamingOptions` field and (b) does not have the unused `gaxOpts` and `autoPaginate` fields. As part of this commit, some TS `as` type assertions are no longer needed.

There is one small breaking change in this commit -- the options passed to `Topic#subscription` are no longer mutated. Instead, a new options object (of a different type) is created. Since the options are no longer mutated, a small change to one of the unit tests was necessary.

Test plan: TS builds and all tests pass

- [x] Tests and linter pass
- [x] Code coverage does not decrease (if any source code was changed)
- [x] Appropriate docs were updated (if necessary)
