### PR TITLE
refactor: use core grpc

### DIFF
--- a/package.json
+++ b/package.json
@@ -63,6 +63,7 @@
     "extend": "^3.0.1",
     "google-auth-library": "^3.0.0",
     "google-gax": "^1.0.0",
+    "grpc": "^1.20.3",
     "is-stream-ended": "^0.1.4",
     "lodash.merge": "^4.6.0",
     "lodash.snakecase": "^4.1.1",

--- a/src/pubsub.ts
+++ b/src/pubsub.ts
@@ -21,6 +21,7 @@ import is from '@sindresorhus/is';
 import * as extend from 'extend';
 import {GoogleAuth} from 'google-auth-library';
 import * as gax from 'google-gax';
+import * as grpc from 'grpc';
 
 const PKG = require('../../package.json');
 const v1 = require('./v1');
@@ -48,7 +49,6 @@ import {google} from '../proto/pubsub';
 import {ServiceError, ChannelCredentials} from 'grpc';
 
 const opts = {} as gax.GrpcClientOptions;
-const {grpc} = new gax.GrpcClient(opts);
 
 /**
  * Project ID placeholder.
@@ -263,6 +263,7 @@ export class PubSub {
     }
     this.options = Object.assign(
       {
+        grpc,
         'grpc.keepalive_time_ms': 300000,
         'grpc.max_send_message_length': -1,
         'grpc.max_receive_message_length': 20000001,


### PR DESCRIPTION
I think the recent upgrade to gax 1.x borked master, I think this should fix it.

- [x] Tests and linter pass
- [x] Code coverage does not decrease (if any source code was changed)
- [x] Appropriate docs were updated (if necessary)
