### PR TITLE
fix!: issue in subscriptions.formatMetadata_

### DIFF
--- a/src/subscription.ts
+++ b/src/subscription.ts
@@ -50,6 +50,7 @@ export type PushConfig = google.pubsub.v1.IPushConfig;
 
 export type SubscriptionMetadata = {
   messageRetentionDuration?: google.protobuf.IDuration | number;
+  retainAckedMessages?: boolean;
   pushEndpoint?: string;
 } & Omit<google.pubsub.v1.ISubscription, 'messageRetentionDuration'>;
 

--- a/src/subscription.ts
+++ b/src/subscription.ts
@@ -1026,7 +1026,6 @@ export class Subscription extends EventEmitter {
     const formatted = extend(true, {}, metadata);
 
     if (typeof metadata.messageRetentionDuration === 'number') {
-      formatted.retainAckedMessages = true;
       (formatted as google.pubsub.v1.ISubscription).messageRetentionDuration = {
         seconds: metadata.messageRetentionDuration,
         nanos: 0,

--- a/system-test/pubsub.ts
+++ b/system-test/pubsub.ts
@@ -328,6 +328,7 @@ describe('pubsub', () => {
       const subName = generateSubName();
       const threeDaysInSeconds = 3 * 24 * 60 * 60;
       const callOptions = {
+        retainAckedMessages: true,
         messageRetentionDuration: threeDaysInSeconds,
         topic: '',
         name: '',
@@ -339,7 +340,7 @@ describe('pubsub', () => {
         sub!.getMetadata((err, metadata) => {
           assert.ifError(err);
 
-          assert.strictEqual(metadata!.retainAckedMessages, true);
+          assert.strictEqual(metadata!.retainAckedMessages, false);
           assert.strictEqual(
             Number(metadata!.messageRetentionDuration!.seconds),
             threeDaysInSeconds
@@ -354,6 +355,36 @@ describe('pubsub', () => {
       });
     });
 
+    it('should create a subscription without message retention', done => {
+      const subName = generateSubName();
+      const threeDaysInSeconds = 3 * 24 * 60 * 60;
+      const callOptions = {
+        messageRetentionDuration: threeDaysInSeconds,
+        topic: '',
+        name: '',
+      };
+
+      topic.createSubscription(subName, callOptions, (err, sub) => {
+        assert.ifError(err);
+
+        sub!.getMetadata((err, metadata) => {
+          assert.ifError(err);
+
+          assert.strictEqual(metadata!.retainAckedMessages, false);
+          assert.strictEqual(
+            Number(metadata!.messageRetentionDuration!.seconds),
+            threeDaysInSeconds
+          );
+          assert.strictEqual(
+            Number(metadata!.messageRetentionDuration!.nanos),
+            0
+          );
+
+          sub!.delete(done);
+        });
+      });
+    });
+    
     it('should set metadata for a subscription', () => {
       const subscription = topic.subscription(generateSubName());
       const threeDaysInSeconds = 3 * 24 * 60 * 60;
@@ -362,6 +393,7 @@ describe('pubsub', () => {
         .create()
         .then(() => {
           return subscription.setMetadata({
+            retainAckedMessages: true,
             messageRetentionDuration: threeDaysInSeconds,
           });
         })

--- a/system-test/pubsub.ts
+++ b/system-test/pubsub.ts
@@ -340,7 +340,7 @@ describe('pubsub', () => {
         sub!.getMetadata((err, metadata) => {
           assert.ifError(err);
 
-          assert.strictEqual(metadata!.retainAckedMessages, false);
+          assert.strictEqual(metadata!.retainAckedMessages, true);
           assert.strictEqual(
             Number(metadata!.messageRetentionDuration!.seconds),
             threeDaysInSeconds
@@ -384,7 +384,7 @@ describe('pubsub', () => {
         });
       });
     });
-    
+
     it('should set metadata for a subscription', () => {
       const subscription = topic.subscription(generateSubName());
       const threeDaysInSeconds = 3 * 24 * 60 * 60;

--- a/test/subscription.ts
+++ b/test/subscription.ts
@@ -227,7 +227,6 @@ describe('Subscription', () => {
 
       const formatted = Subscription.formatMetadata_(metadata);
 
-      assert.strictEqual(formatted.retainAckedMessages, true);
       assert.strictEqual(formatted.messageRetentionDuration!.nanos, 0);
 
       assert.strictEqual(


### PR DESCRIPTION
Fixes #623.

The current code is this:

```
    if (typeof metadata.messageRetentionDuration === 'number') {
      formatted.retainAckedMessages = true;
      (formatted as google.pubsub.v1.ISubscription).messageRetentionDuration = {
        seconds: metadata.messageRetentionDuration,
        nanos: 0,
      };
    }
```

`formatted.retainAckedMessages = true;` shouldn't be there.

Fixes #<issue_number_goes_here> (it's a good idea to open an issue first for discussion)

- [x] Tests and linter pass
- [ ] Code coverage does not decrease (if any source code was changed)
- [ ] Appropriate docs were updated (if necessary)
