### PR TITLE
fix(typescript): pin grpc to previous working version

### DIFF
--- a/package.json
+++ b/package.json
@@ -63,7 +63,7 @@
     "extend": "^3.0.1",
     "google-auth-library": "^3.0.0",
     "google-gax": "^1.0.0",
-    "grpc": "^1.20.3",
+    "grpc": "1.20.3",
     "is-stream-ended": "^0.1.4",
     "lodash.snakecase": "^4.1.1",
     "p-defer": "^2.0.1",


### PR DESCRIPTION
Relates to https://github.com/grpc/grpc-node/issues/883

Latest version of the gRPC extension results in a slew of TypeScript errors. I believe the culprit is the `@types/protobufjs` package (which is deprecated). I think the best course of action is to just pin it for now.