### PR TITLE
docs(subscription): mention 100 stream limit

### DIFF
--- a/src/subscription.ts
+++ b/src/subscription.ts
@@ -134,6 +134,12 @@ export type SetSubscriptionMetadataResponse = MetadataResponse;
  * nack of such message when the processing is done. **Note:** message
  * redelivery is still possible.
  *
+ * By default each {@link PubSub} instance can handle 100 open streams, with
+ * default options this translates to 20 Subscriptions per PubSub instance.
+ * If you desire to use more than 20 Subscriptions you can either create
+ * multiple PubSub instances or lower the `options.streamingOptions.maxStreams`
+ * value.
+ *
  * @class
  *
  * @param {PubSub} pubsub PubSub object.

--- a/src/subscription.ts
+++ b/src/subscription.ts
@@ -138,7 +138,7 @@ export type SetSubscriptionMetadataResponse = MetadataResponse;
  * default options this translates to less than 20 Subscriptions per PubSub
  * instance. If you wish to create more Subscriptions than that, you can either
  * create multiple PubSub instances or lower the
- * `options.streamingOptions.maxStreams` value.
+ * `options.streamingOptions.maxStreams` value on each Subscription object.
  *
  * @class
  *

--- a/src/subscription.ts
+++ b/src/subscription.ts
@@ -135,10 +135,10 @@ export type SetSubscriptionMetadataResponse = MetadataResponse;
  * redelivery is still possible.
  *
  * By default each {@link PubSub} instance can handle 100 open streams, with
- * default options this translates to 20 Subscriptions per PubSub instance.
- * If you desire to use more than 20 Subscriptions you can either create
- * multiple PubSub instances or lower the `options.streamingOptions.maxStreams`
- * value.
+ * default options this translates to less than 20 Subscriptions per PubSub
+ * instance. If you wish to create more Subscriptions than that, you can either
+ * create multiple PubSub instances or lower the
+ * `options.streamingOptions.maxStreams` value.
  *
  * @class
  *


### PR DESCRIPTION
Relates to #550

- [x] Tests and linter pass
- [x] Code coverage does not decrease (if any source code was changed)
- [x] Appropriate docs were updated (if necessary)
