### PR TITLE
deps: upgrade extend dependency to 3.0.2 due to CVE-2018-16492

### DIFF
--- a/package.json
+++ b/package.json
@@ -59,7 +59,7 @@
     "@types/long": "^4.0.0",
     "arrify": "^2.0.0",
     "async-each": "^1.0.1",
-    "extend": "^3.0.1",
+    "extend": "^3.0.2",
     "google-auth-library": "^3.0.0",
     "google-gax": "^1.0.0",
     "grpc": "1.21.1",


### PR DESCRIPTION
### Upgrade module extend to fix CVE-2018-16492 Prototype pollution vulnerability

Fixes #643 

The extend module used in pubsub package is 3.0.1 which has known vulnerability - Refer https://nvd.nist.gov/vuln/detail/CVE-2018-16492

This vulnerability is fixed in version 3.0.2 of extend module.
