### PR TITLE
docs(subscription): fix broken links to pubsub methods

### DIFF
--- a/src/subscription.ts
+++ b/src/subscription.ts
@@ -104,12 +104,12 @@ export type SetSubscriptionMetadataResponse = MetadataResponse;
  *
  * Subscriptions are sometimes retrieved when using various methods:
  *
- * - {@link Pubsub#getSubscriptions}
+ * - {@link PubSub#getSubscriptions}
  * - {@link Topic#getSubscriptions}
  *
  * Subscription objects may be created directly with:
  *
- * - {@link Pubsub#createSubscription}
+ * - {@link PubSub#createSubscription}
  * - {@link Topic#createSubscription}
  *
  * All Subscription objects are instances of an


### PR DESCRIPTION
Fixes #685

- [x] Tests and linter pass
- [x] Code coverage does not decrease (if any source code was changed)
- [x] Appropriate docs were updated (if necessary)
