### PR TITLE
docs: use jsdoc-fresh as the template

### DIFF
--- a/.jsdoc.js
+++ b/.jsdoc.js
@@ -20,7 +20,7 @@ module.exports = {
   opts: {
     readme: './README.md',
     package: './package.json',
-    template: './node_modules/jsdoc-baseline',
+    template: './node_modules/jsdoc-fresh',
     recurse: true,
     verbose: true,
     destination: './docs/'

--- a/package.json
+++ b/package.json
@@ -88,7 +88,7 @@
     "gts": "^1.0.0",
     "intelli-espower-loader": "^1.0.1",
     "jsdoc": "^3.6.2",
-    "jsdoc-baseline": "^0.1.0",
+    "jsdoc-fresh": "^1.0.1",
     "linkinator": "^1.5.0",
     "mkdirp": "^0.5.1",
     "mocha": "^6.0.0",

--- a/src/index.ts
+++ b/src/index.ts
@@ -31,21 +31,19 @@
  * @module {PubSub} @google-cloud/pubsub
  * @alias nodejs-pubsub
  *
- * @example <caption>Install the client library with <a
- * href="https://www.npmjs.com/">npm</a>:</caption> npm install --save
- * @google-cloud/pubsub
+ * @example <caption>Install the client library with <a href="https://www.npmjs.com/">npm</a>:</caption>
+ * npm install @google-cloud/pubsub
  *
  * @example <caption>Import the client library</caption>
  * const {PubSub} = require('@google-cloud/pubsub');
  *
- * @example <caption>Create a client that uses <a
- * href="https://cloud.google.com/docs/authentication/production#providing_credentials_to_your_application">Application
- * Default Credentials (ADC)</a>:</caption> const pubsub = new PubSub();
+ * @example <caption>Create a client that uses <a href="https://cloud.google.com/docs/authentication/production#providing_credentials_to_your_application">Application Default Credentials (ADC)</a>:</caption>
+ * const pubsub = new PubSub();
  *
- * @example <caption>Create a client with <a
- * href="https://cloud.google.com/docs/authentication/production#obtaining_and_providing_service_account_credentials_manually">explicit
- * credentials</a>:</caption> const pubsub = new PubSub({ projectId:
- * 'your-project-id', keyFilename: '/path/to/keyfile.json'
+ * @example <caption>Create a client with <a href="https://cloud.google.com/docs/authentication/production#obtaining_and_providing_service_account_credentials_manually">explicit credentials</a>:</caption>
+ * const pubsub = new PubSub({
+ *   projectId: 'your-project-id',
+ *   keyFilename: '/path/to/keyfile.json'
  * });
  *
  * @example <caption>include:samples/quickstart.js</caption>

--- a/src/pubsub.ts
+++ b/src/pubsub.ts
@@ -218,14 +218,13 @@ interface GetClientCallback {
  * @example <caption>Import the client library</caption>
  * const {PubSub} = require('@google-cloud/pubsub');
  *
- * @example <caption>Create a client that uses <a
- * href="https://cloud.google.com/docs/authentication/production#providing_credentials_to_your_application">Application
- * Default Credentials (ADC)</a>:</caption> const pubsub = new PubSub();
+ * @example <caption>Create a client that uses <a href="https://cloud.google.com/docs/authentication/production#providing_credentials_to_your_application">Application Default Credentials (ADC)</a>:</caption>
+ * const pubsub = new PubSub();
  *
- * @example <caption>Create a client with <a
- * href="https://cloud.google.com/docs/authentication/production#obtaining_and_providing_service_account_credentials_manually">explicit
- * credentials</a>:</caption> const pubsub = new PubSub({ projectId:
- * 'your-project-id', keyFilename: '/path/to/keyfile.json'
+ * @example <caption>Create a client with <a href="https://cloud.google.com/docs/authentication/production#obtaining_and_providing_service_account_credentials_manually">explicit credentials</a>:</caption>
+ * const pubsub = new PubSub({
+ *   projectId: 'your-project-id',
+ *   keyFilename: '/path/to/keyfile.json'
  * });
  *
  * @example <caption>include:samples/quickstart.js</caption>
@@ -349,12 +348,9 @@ export class PubSub {
    * @throws {Error} If a Topic instance or topic name is not provided.
    * @throws {Error} If a subscription name is not provided.
    *
-   * @param {Topic|string} topic The Topic to create a
-   *     subscription to.
+   * @param {Topic|string} topic The Topic to create a subscription to.
    * @param {string} name The name of the subscription.
-   * @param {CreateSubscriptionRequest} [options] See a
-   *     [Subscription
-   * resource](https://cloud.google.com/pubsub/docs/reference/rest/v1/projects.subscriptions).
+   * @param {CreateSubscriptionRequest} [options] See a [Subscription resource](https://cloud.google.com/pubsub/docs/reference/rest/v1/projects.subscriptions).
    * @param {CreateSubscriptionCallback} [callback] Callback function.
    * @returns {Promise<CreateSubscriptionResponse>}
    *
@@ -369,11 +365,12 @@ export class PubSub {
    *
    * pubsub.createSubscription(topic, name, callback);
    *
-   * @example <caption>If the callback is omitted, we'll return a
-   * Promise.</caption> pubsub.createSubscription(topic,
-   * name).then(function(data) { const subscription = data[0]; const apiResponse
-   * = data[1];
-   * });
+   * @example <caption>If the callback is omitted, we'll return a Promise.</caption>
+   * pubsub.createSubscription(topic, name)
+   *   .then(function(data) {
+   *     const subscription = data[0];
+   *     const apiResponse = data[1];
+   *   });
    */
   createSubscription(
     topic: Topic | string,


### PR DESCRIPTION
This fixes *many* problems we had with the jsdoc-baseline template, including not rendering `ClientConfig` properties in line with the constructor.

![image](https://user-images.githubusercontent.com/534619/62150977-25d3b680-b2b4-11e9-9d5a-1356419639eb.png)
