### PR TITLE
docs(subscription): prevent sub options from getting removed

### DIFF
--- a/src/lease-manager.ts
+++ b/src/lease-manager.ts
@@ -19,6 +19,13 @@ import {freemem} from 'os';
 
 import {Message, Subscriber} from './subscriber';
 
+export interface FlowControlOptions {
+  allowExcessMessages?: boolean;
+  maxBytes?: number;
+  maxExtension?: number;
+  maxMessages?: number;
+}
+
 /**
  * @typedef {object} FlowControlOptions
  * @property {boolean} [allowExcessMessages=true] PubSub delivers messages in
@@ -38,13 +45,6 @@ import {Message, Subscriber} from './subscriber';
  *     any given message batch could contain a greater number of messages than
  *     the desired amount of messages.
  */
-export interface FlowControlOptions {
-  allowExcessMessages?: boolean;
-  maxBytes?: number;
-  maxExtension?: number;
-  maxMessages?: number;
-}
-
 /**
  * Manages a Subscribers inventory while auto-magically extending the message
  * deadlines.

--- a/src/message-queues.ts
+++ b/src/message-queues.ts
@@ -56,7 +56,7 @@ export class BatchError extends Error implements ServiceError {
 /**
  * @typedef {object} BatchOptions
  * @property {object} [callOptions] Request configuration option, outlined
- *     here: {@link https://googleapis.github.io/gax-nodejs/CallSettings.html}.
+ *     here: {@link https://googleapis.github.io/gax-nodejs/interfaces/CallOptions.html}.
  * @property {number} [maxMessages=3000] Maximum number of messages allowed in
  *     each batch sent.
  * @property {number} [maxMilliseconds=100] Maximum duration to wait before

--- a/src/message-queues.ts
+++ b/src/message-queues.ts
@@ -22,16 +22,6 @@ import {Message, Subscriber} from './subscriber';
 
 type QueuedMessages = Array<[string, number?]>;
 
-/**
- * @typedef {object} BatchOptions
- * @property {object} [callOptions] Request configuration option, outlined
- *     here: {@link https://googleapis.github.io/gax-nodejs/CallSettings.html}.
- * @property {number} [maxMessages=3000] Maximum number of messages allowed in
- *     each batch sent.
- * @property {number} [maxMilliseconds=100] Maximum duration to wait before
- *     sending a batch. Batches can be sent earlier if the maxMessages option
- *     is met before the configured duration has passed.
- */
 export interface BatchOptions {
   callOptions?: CallOptions;
   maxMessages?: number;
@@ -63,6 +53,16 @@ export class BatchError extends Error implements ServiceError {
   }
 }
 
+/**
+ * @typedef {object} BatchOptions
+ * @property {object} [callOptions] Request configuration option, outlined
+ *     here: {@link https://googleapis.github.io/gax-nodejs/CallSettings.html}.
+ * @property {number} [maxMessages=3000] Maximum number of messages allowed in
+ *     each batch sent.
+ * @property {number} [maxMilliseconds=100] Maximum duration to wait before
+ *     sending a batch. Batches can be sent earlier if the maxMessages option
+ *     is met before the configured duration has passed.
+ */
 /**
  * Class for buffering ack/modAck requests.
  *

--- a/src/message-stream.ts
+++ b/src/message-stream.ts
@@ -101,6 +101,12 @@ export class ChannelError extends Error implements ServiceError {
   }
 }
 
+export interface MessageStreamOptions {
+  highWaterMark?: number;
+  maxStreams?: number;
+  timeout?: number;
+}
+
 /**
  * @typedef {object} MessageStreamOptions
  * @property {number} [highWaterMark=0] Configures the Buffer level for all
@@ -110,12 +116,6 @@ export class ChannelError extends Error implements ServiceError {
  * @property {number} [maxStreams=5] Number of streaming connections to make.
  * @property {number} [timeout=300000] Timeout for establishing a connection.
  */
-export interface MessageStreamOptions {
-  highWaterMark?: number;
-  maxStreams?: number;
-  timeout?: number;
-}
-
 /**
  * Streaming class used to manage multiple StreamingPull requests.
  *


### PR DESCRIPTION
Another case of TypeScript removing docs because of where they were declared.

Fixes #696 

- [x] Tests and linter pass
- [x] Code coverage does not decrease (if any source code was changed)
- [x] Appropriate docs were updated (if necessary)
