### PR TITLE
feat(debug): capture stack trace in errors rather than message

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -143,3 +143,10 @@ export {
   Topic,
   TopicMetadata,
 } from './topic';
+
+if (process.env.DEBUG_GRPC) {
+  console.info('gRPC logging set to verbose');
+  const {setLogger, setLogVerbosity, logVerbosity} = require('@grpc/grpc-js');
+  setLogger(console);
+  setLogVerbosity(logVerbosity.DEBUG);
+}

--- a/src/message-queues.ts
+++ b/src/message-queues.ts
@@ -43,7 +43,7 @@ export class BatchError extends Error implements ServiceError {
   metadata: Metadata;
   constructor(err: ServiceError, ackIds: string[], rpc: string) {
     super(
-      `Failed to "${rpc}" for ${ackIds.length} message(s). Reason: ${err.message}`
+      `Failed to "${rpc}" for ${ackIds.length} message(s). Reason: ${err.stack}`
     );
 
     this.ackIds = ackIds;

--- a/src/message-queues.ts
+++ b/src/message-queues.ts
@@ -43,7 +43,9 @@ export class BatchError extends Error implements ServiceError {
   metadata: Metadata;
   constructor(err: ServiceError, ackIds: string[], rpc: string) {
     super(
-      `Failed to "${rpc}" for ${ackIds.length} message(s). Reason: ${err.stack}`
+      `Failed to "${rpc}" for ${ackIds.length} message(s). Reason: ${
+        process.env.DEBUG_GRPC ? err.stack : err.message
+      }`
     );
 
     this.ackIds = ackIds;

--- a/src/message-stream.ts
+++ b/src/message-stream.ts
@@ -92,7 +92,7 @@ export class ChannelError extends Error implements ServiceError {
   details: string;
   metadata: Metadata;
   constructor(err: Error) {
-    super(`Failed to connect to channel. Reason: ${err.message}`);
+    super(`Failed to connect to channel. Reason: ${err.stack}`);
     this.code = err.message.includes('deadline')
       ? status.DEADLINE_EXCEEDED
       : status.UNKNOWN;

--- a/src/message-stream.ts
+++ b/src/message-stream.ts
@@ -92,7 +92,11 @@ export class ChannelError extends Error implements ServiceError {
   details: string;
   metadata: Metadata;
   constructor(err: Error) {
-    super(`Failed to connect to channel. Reason: ${err.stack}`);
+    super(
+      `Failed to connect to channel. Reason: ${
+        process.env.DEBUG_GRPC ? err.stack : err.message
+      }`
+    );
     this.code = err.message.includes('deadline')
       ? status.DEADLINE_EXCEEDED
       : status.UNKNOWN;


### PR DESCRIPTION
This provides us with more detailed debug information so that we can better delve into intermittent issues with `grpc-js`.