### PR TITLE
docs: update batch publish sample

### DIFF
--- a/samples/system-test/topics.test.js
+++ b/samples/system-test/topics.test.js
@@ -1,5 +1,5 @@
 /*!
- * Copyright 2019 Google Inc. All Rights Reserved.
+ * Copyright 2019 Google LLC. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/samples/system-test/topics.test.js
+++ b/samples/system-test/topics.test.js
@@ -1,17 +1,16 @@
-/**
- * Copyright 2019, Google, LLC.
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *    http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
+// Copyright 2019 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 
 'use strict';
 

--- a/samples/system-test/topics.test.js
+++ b/samples/system-test/topics.test.js
@@ -1,10 +1,11 @@
-/**
- * Copyright 2019, Google, LLC.
+/*!
+ * Copyright 2019 Google Inc. All Rights Reserved.
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *    http://www.apache.org/licenses/LICENSE-2.0
+ *      http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/samples/system-test/topics.test.js
+++ b/samples/system-test/topics.test.js
@@ -156,7 +156,7 @@ describe('topics', () => {
   });
 
   it('should publish with specific batch settings', async () => {
-    const waitTime = 5000;
+    const waitTime = 1000;
     const [subscription] = await pubsub
       .topic(topicNameOne)
       .subscription(subscriptionNameThree)
@@ -170,7 +170,7 @@ describe('topics', () => {
     const actualWait = publishTime.getTime() - startTime;
 
     assert.strictEqual(data.toString(), expectedMessage.data);
-    assert(actualWait >= waitTime);
+    assert(actualWait <= waitTime);
   });
 
   it('should publish with retry settings', async () => {

--- a/samples/system-test/topics.test.js
+++ b/samples/system-test/topics.test.js
@@ -1,11 +1,10 @@
-/*!
- * Copyright 2019 Google LLC. All Rights Reserved.
- *
+/**
+ * Copyright 2019, Google, LLC.
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *    http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/samples/topics.js
+++ b/samples/topics.js
@@ -157,16 +157,20 @@ async function publishBatchedMessages(
   // Publishes the message as a string, e.g. "Hello, world!" or JSON.stringify(someObject)
   const dataBuffer = Buffer.from(data);
 
-  const [messageId] = await pubsub
+  const batchPublisher = pubsub
     .topic(topicName, {
       batching: {
         maxMessages: maxMessages,
         maxMilliseconds: maxWaitTime,
       },
-    })
-    .publish(dataBuffer);
-  console.log(`Message ${messageId} published.`);
+    });
 
+  for(var i = 1; i < 11; i++) {
+    (async () => {
+      let messageId = await batchPublisher.publish(dataBuffer)
+      console.log(`Message ${messageId} published.`);
+    })();
+  }
   // [END pubsub_publisher_batch_settings]
 }
 

--- a/samples/topics.js
+++ b/samples/topics.js
@@ -1,5 +1,5 @@
 /*!
- * Copyright 2019 Google Inc. All Rights Reserved.
+ * Copyright 2019 Google LLC. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -158,17 +158,16 @@ async function publishBatchedMessages(
   // Publishes the message as a string, e.g. "Hello, world!" or JSON.stringify(someObject)
   const dataBuffer = Buffer.from(data);
 
-  const batchPublisher = pubsub
-    .topic(topicName, {
-      batching: {
-        maxMessages: maxMessages,
-        maxMilliseconds: maxWaitTime,
-      },
-    });
+  const batchPublisher = pubsub.topic(topicName, {
+    batching: {
+      maxMessages: maxMessages,
+      maxMilliseconds: maxWaitTime,
+    },
+  });
 
-  for(var i = 1; i < 11; i++) {
+  for (let i = 1; i < 11; i++) {
     (async () => {
-      let messageId = await batchPublisher.publish(dataBuffer)
+      const messageId = await batchPublisher.publish(dataBuffer);
       console.log(`Message ${messageId} published.`);
     })();
   }

--- a/samples/topics.js
+++ b/samples/topics.js
@@ -1,17 +1,16 @@
-/**
- * Copyright 2019, Google, LLC.
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *    http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
+// Copyright 2019 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 
 /**
  * This application demonstrates how to perform basic operations on topics with

--- a/samples/topics.js
+++ b/samples/topics.js
@@ -1,10 +1,11 @@
-/**
- * Copyright 2017, Google, Inc.
+/*!
+ * Copyright 2019 Google Inc. All Rights Reserved.
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *    http://www.apache.org/licenses/LICENSE-2.0
+ *      http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/samples/topics.js
+++ b/samples/topics.js
@@ -163,7 +163,7 @@ async function publishBatchedMessages(
     },
   });
 
-  for (let i = 1; i < 11; i++) {
+  for (let i = 0; i < 10; i++) {
     (async () => {
       const messageId = await batchPublisher.publish(dataBuffer);
       console.log(`Message ${messageId} published.`);

--- a/samples/topics.js
+++ b/samples/topics.js
@@ -1,11 +1,10 @@
-/*!
- * Copyright 2019 Google LLC. All Rights Reserved.
- *
+/**
+ * Copyright 2019, Google, LLC.
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *    http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,


### PR DESCRIPTION
+ Wraps `await` in an anonymous `async` function. This makes sure that the code enclosed in the region tags can run as copied and pasted. 
+ Publish multiple messages instead of one to better showcase what batch publishing is all about. 
+ Update the test to show that when `maxMessages` is 10, publishing 10 messages should take shorter than the `maxWaitTime`. 