### PR TITLE
feat: update IAM protos

### DIFF
--- a/proto/iam.d.ts
+++ b/proto/iam.d.ts
@@ -1,5 +1,4 @@
 import * as $protobuf from "protobufjs";
-import * as Long from "long";
 /** Namespace google. */
 export namespace google {
 
@@ -197,6 +196,9 @@ export namespace google {
 
                 /** GetIamPolicyRequest resource */
                 resource?: (string|null);
+
+                /** GetIamPolicyRequest options */
+                options?: (google.iam.v1.IGetPolicyOptions|null);
             }
 
             /** Represents a GetIamPolicyRequest. */
@@ -210,6 +212,9 @@ export namespace google {
 
                 /** GetIamPolicyRequest resource. */
                 public resource: string;
+
+                /** GetIamPolicyRequest options. */
+                public options?: (google.iam.v1.IGetPolicyOptions|null);
 
                 /**
                  * Creates a new GetIamPolicyRequest instance using the specified properties.
@@ -468,6 +473,96 @@ export namespace google {
                 public toJSON(): { [k: string]: any };
             }
 
+            /** Properties of a GetPolicyOptions. */
+            interface IGetPolicyOptions {
+
+                /** GetPolicyOptions requestedPolicyVersion */
+                requestedPolicyVersion?: (number|null);
+            }
+
+            /** Represents a GetPolicyOptions. */
+            class GetPolicyOptions implements IGetPolicyOptions {
+
+                /**
+                 * Constructs a new GetPolicyOptions.
+                 * @param [properties] Properties to set
+                 */
+                constructor(properties?: google.iam.v1.IGetPolicyOptions);
+
+                /** GetPolicyOptions requestedPolicyVersion. */
+                public requestedPolicyVersion: number;
+
+                /**
+                 * Creates a new GetPolicyOptions instance using the specified properties.
+                 * @param [properties] Properties to set
+                 * @returns GetPolicyOptions instance
+                 */
+                public static create(properties?: google.iam.v1.IGetPolicyOptions): google.iam.v1.GetPolicyOptions;
+
+                /**
+                 * Encodes the specified GetPolicyOptions message. Does not implicitly {@link google.iam.v1.GetPolicyOptions.verify|verify} messages.
+                 * @param message GetPolicyOptions message or plain object to encode
+                 * @param [writer] Writer to encode to
+                 * @returns Writer
+                 */
+                public static encode(message: google.iam.v1.IGetPolicyOptions, writer?: $protobuf.Writer): $protobuf.Writer;
+
+                /**
+                 * Encodes the specified GetPolicyOptions message, length delimited. Does not implicitly {@link google.iam.v1.GetPolicyOptions.verify|verify} messages.
+                 * @param message GetPolicyOptions message or plain object to encode
+                 * @param [writer] Writer to encode to
+                 * @returns Writer
+                 */
+                public static encodeDelimited(message: google.iam.v1.IGetPolicyOptions, writer?: $protobuf.Writer): $protobuf.Writer;
+
+                /**
+                 * Decodes a GetPolicyOptions message from the specified reader or buffer.
+                 * @param reader Reader or buffer to decode from
+                 * @param [length] Message length if known beforehand
+                 * @returns GetPolicyOptions
+                 * @throws {Error} If the payload is not a reader or valid buffer
+                 * @throws {$protobuf.util.ProtocolError} If required fields are missing
+                 */
+                public static decode(reader: ($protobuf.Reader|Uint8Array), length?: number): google.iam.v1.GetPolicyOptions;
+
+                /**
+                 * Decodes a GetPolicyOptions message from the specified reader or buffer, length delimited.
+                 * @param reader Reader or buffer to decode from
+                 * @returns GetPolicyOptions
+                 * @throws {Error} If the payload is not a reader or valid buffer
+                 * @throws {$protobuf.util.ProtocolError} If required fields are missing
+                 */
+                public static decodeDelimited(reader: ($protobuf.Reader|Uint8Array)): google.iam.v1.GetPolicyOptions;
+
+                /**
+                 * Verifies a GetPolicyOptions message.
+                 * @param message Plain object to verify
+                 * @returns `null` if valid, otherwise the reason why it is not
+                 */
+                public static verify(message: { [k: string]: any }): (string|null);
+
+                /**
+                 * Creates a GetPolicyOptions message from a plain object. Also converts values to their respective internal types.
+                 * @param object Plain object
+                 * @returns GetPolicyOptions
+                 */
+                public static fromObject(object: { [k: string]: any }): google.iam.v1.GetPolicyOptions;
+
+                /**
+                 * Creates a plain object from a GetPolicyOptions message. Also converts values to other types if specified.
+                 * @param message GetPolicyOptions
+                 * @param [options] Conversion options
+                 * @returns Plain object
+                 */
+                public static toObject(message: google.iam.v1.GetPolicyOptions, options?: $protobuf.IConversionOptions): { [k: string]: any };
+
+                /**
+                 * Converts this GetPolicyOptions to JSON.
+                 * @returns JSON object
+                 */
+                public toJSON(): { [k: string]: any };
+            }
+
             /** Properties of a Policy. */
             interface IPolicy {
 
@@ -578,6 +673,9 @@ export namespace google {
 
                 /** Binding members */
                 members?: (string[]|null);
+
+                /** Binding condition */
+                condition?: (google.type.IExpr|null);
             }
 
             /** Represents a Binding. */
@@ -594,6 +692,9 @@ export namespace google {
 
                 /** Binding members. */
                 public members: string[];
+
+                /** Binding condition. */
+                public condition?: (google.type.IExpr|null);
 
                 /**
                  * Creates a new Binding instance using the specified properties.
@@ -671,6 +772,9 @@ export namespace google {
 
                 /** PolicyDelta bindingDeltas */
                 bindingDeltas?: (google.iam.v1.IBindingDelta[]|null);
+
+                /** PolicyDelta auditConfigDeltas */
+                auditConfigDeltas?: (google.iam.v1.IAuditConfigDelta[]|null);
             }
 
             /** Represents a PolicyDelta. */
@@ -684,6 +788,9 @@ export namespace google {
 
                 /** PolicyDelta bindingDeltas. */
                 public bindingDeltas: google.iam.v1.IBindingDelta[];
+
+                /** PolicyDelta auditConfigDeltas. */
+                public auditConfigDeltas: google.iam.v1.IAuditConfigDelta[];
 
                 /**
                  * Creates a new PolicyDelta instance using the specified properties.
@@ -767,6 +874,9 @@ export namespace google {
 
                 /** BindingDelta member */
                 member?: (string|null);
+
+                /** BindingDelta condition */
+                condition?: (google.type.IExpr|null);
             }
 
             /** Represents a BindingDelta. */
@@ -786,6 +896,9 @@ export namespace google {
 
                 /** BindingDelta member. */
                 public member: string;
+
+                /** BindingDelta condition. */
+                public condition?: (google.type.IExpr|null);
 
                 /**
                  * Creates a new BindingDelta instance using the specified properties.
@@ -859,6 +972,124 @@ export namespace google {
             }
 
             namespace BindingDelta {
+
+                /** Action enum. */
+                enum Action {
+                    ACTION_UNSPECIFIED = 0,
+                    ADD = 1,
+                    REMOVE = 2
+                }
+            }
+
+            /** Properties of an AuditConfigDelta. */
+            interface IAuditConfigDelta {
+
+                /** AuditConfigDelta action */
+                action?: (google.iam.v1.AuditConfigDelta.Action|null);
+
+                /** AuditConfigDelta service */
+                service?: (string|null);
+
+                /** AuditConfigDelta exemptedMember */
+                exemptedMember?: (string|null);
+
+                /** AuditConfigDelta logType */
+                logType?: (string|null);
+            }
+
+            /** Represents an AuditConfigDelta. */
+            class AuditConfigDelta implements IAuditConfigDelta {
+
+                /**
+                 * Constructs a new AuditConfigDelta.
+                 * @param [properties] Properties to set
+                 */
+                constructor(properties?: google.iam.v1.IAuditConfigDelta);
+
+                /** AuditConfigDelta action. */
+                public action: google.iam.v1.AuditConfigDelta.Action;
+
+                /** AuditConfigDelta service. */
+                public service: string;
+
+                /** AuditConfigDelta exemptedMember. */
+                public exemptedMember: string;
+
+                /** AuditConfigDelta logType. */
+                public logType: string;
+
+                /**
+                 * Creates a new AuditConfigDelta instance using the specified properties.
+                 * @param [properties] Properties to set
+                 * @returns AuditConfigDelta instance
+                 */
+                public static create(properties?: google.iam.v1.IAuditConfigDelta): google.iam.v1.AuditConfigDelta;
+
+                /**
+                 * Encodes the specified AuditConfigDelta message. Does not implicitly {@link google.iam.v1.AuditConfigDelta.verify|verify} messages.
+                 * @param message AuditConfigDelta message or plain object to encode
+                 * @param [writer] Writer to encode to
+                 * @returns Writer
+                 */
+                public static encode(message: google.iam.v1.IAuditConfigDelta, writer?: $protobuf.Writer): $protobuf.Writer;
+
+                /**
+                 * Encodes the specified AuditConfigDelta message, length delimited. Does not implicitly {@link google.iam.v1.AuditConfigDelta.verify|verify} messages.
+                 * @param message AuditConfigDelta message or plain object to encode
+                 * @param [writer] Writer to encode to
+                 * @returns Writer
+                 */
+                public static encodeDelimited(message: google.iam.v1.IAuditConfigDelta, writer?: $protobuf.Writer): $protobuf.Writer;
+
+                /**
+                 * Decodes an AuditConfigDelta message from the specified reader or buffer.
+                 * @param reader Reader or buffer to decode from
+                 * @param [length] Message length if known beforehand
+                 * @returns AuditConfigDelta
+                 * @throws {Error} If the payload is not a reader or valid buffer
+                 * @throws {$protobuf.util.ProtocolError} If required fields are missing
+                 */
+                public static decode(reader: ($protobuf.Reader|Uint8Array), length?: number): google.iam.v1.AuditConfigDelta;
+
+                /**
+                 * Decodes an AuditConfigDelta message from the specified reader or buffer, length delimited.
+                 * @param reader Reader or buffer to decode from
+                 * @returns AuditConfigDelta
+                 * @throws {Error} If the payload is not a reader or valid buffer
+                 * @throws {$protobuf.util.ProtocolError} If required fields are missing
+                 */
+                public static decodeDelimited(reader: ($protobuf.Reader|Uint8Array)): google.iam.v1.AuditConfigDelta;
+
+                /**
+                 * Verifies an AuditConfigDelta message.
+                 * @param message Plain object to verify
+                 * @returns `null` if valid, otherwise the reason why it is not
+                 */
+                public static verify(message: { [k: string]: any }): (string|null);
+
+                /**
+                 * Creates an AuditConfigDelta message from a plain object. Also converts values to their respective internal types.
+                 * @param object Plain object
+                 * @returns AuditConfigDelta
+                 */
+                public static fromObject(object: { [k: string]: any }): google.iam.v1.AuditConfigDelta;
+
+                /**
+                 * Creates a plain object from an AuditConfigDelta message. Also converts values to other types if specified.
+                 * @param message AuditConfigDelta
+                 * @param [options] Conversion options
+                 * @returns Plain object
+                 */
+                public static toObject(message: google.iam.v1.AuditConfigDelta, options?: $protobuf.IConversionOptions): { [k: string]: any };
+
+                /**
+                 * Converts this AuditConfigDelta to JSON.
+                 * @returns JSON object
+                 */
+                public toJSON(): { [k: string]: any };
+            }
+
+            namespace AuditConfigDelta {
 
                 /** Action enum. */
                 enum Action {
@@ -4070,6 +4301,118 @@ export namespace google {
                  */
                 public toJSON(): { [k: string]: any };
             }
+        }
+    }
+
+    /** Namespace type. */
+    namespace type {
+
+        /** Properties of an Expr. */
+        interface IExpr {
+
+            /** Expr expression */
+            expression?: (string|null);
+
+            /** Expr title */
+            title?: (string|null);
+
+            /** Expr description */
+            description?: (string|null);
+
+            /** Expr location */
+            location?: (string|null);
+        }
+
+        /** Represents an Expr. */
+        class Expr implements IExpr {
+
+            /**
+             * Constructs a new Expr.
+             * @param [properties] Properties to set
+             */
+            constructor(properties?: google.type.IExpr);
+
+            /** Expr expression. */
+            public expression: string;
+
+            /** Expr title. */
+            public title: string;
+
+            /** Expr description. */
+            public description: string;
+
+            /** Expr location. */
+            public location: string;
+
+            /**
+             * Creates a new Expr instance using the specified properties.
+             * @param [properties] Properties to set
+             * @returns Expr instance
+             */
+            public static create(properties?: google.type.IExpr): google.type.Expr;
+
+            /**
+             * Encodes the specified Expr message. Does not implicitly {@link google.type.Expr.verify|verify} messages.
+             * @param message Expr message or plain object to encode
+             * @param [writer] Writer to encode to
+             * @returns Writer
+             */
+            public static encode(message: google.type.IExpr, writer?: $protobuf.Writer): $protobuf.Writer;
+
+            /**
+             * Encodes the specified Expr message, length delimited. Does not implicitly {@link google.type.Expr.verify|verify} messages.
+             * @param message Expr message or plain object to encode
+             * @param [writer] Writer to encode to
+             * @returns Writer
+             */
+            public static encodeDelimited(message: google.type.IExpr, writer?: $protobuf.Writer): $protobuf.Writer;
+
+            /**
+             * Decodes an Expr message from the specified reader or buffer.
+             * @param reader Reader or buffer to decode from
+             * @param [length] Message length if known beforehand
+             * @returns Expr
+             * @throws {Error} If the payload is not a reader or valid buffer
+             * @throws {$protobuf.util.ProtocolError} If required fields are missing
+             */
+            public static decode(reader: ($protobuf.Reader|Uint8Array), length?: number): google.type.Expr;
+
+            /**
+             * Decodes an Expr message from the specified reader or buffer, length delimited.
+             * @param reader Reader or buffer to decode from
+             * @returns Expr
+             * @throws {Error} If the payload is not a reader or valid buffer
+             * @throws {$protobuf.util.ProtocolError} If required fields are missing
+             */
+            public static decodeDelimited(reader: ($protobuf.Reader|Uint8Array)): google.type.Expr;
+
+            /**
+             * Verifies an Expr message.
+             * @param message Plain object to verify
+             * @returns `null` if valid, otherwise the reason why it is not
+             */
+            public static verify(message: { [k: string]: any }): (string|null);
+
+            /**
+             * Creates an Expr message from a plain object. Also converts values to their respective internal types.
+             * @param object Plain object
+             * @returns Expr
+             */
+            public static fromObject(object: { [k: string]: any }): google.type.Expr;
+
+            /**
+             * Creates a plain object from an Expr message. Also converts values to other types if specified.
+             * @param message Expr
+             * @param [options] Conversion options
+             * @returns Plain object
+             */
+            public static toObject(message: google.type.Expr, options?: $protobuf.IConversionOptions): { [k: string]: any };
+
+            /**
+             * Converts this Expr to JSON.
+             * @returns JSON object
+             */
+            public toJSON(): { [k: string]: any };
         }
     }
 }

--- a/protos/google/iam/v1/iam_policy.proto
+++ b/protos/google/iam/v1/iam_policy.proto
@@ -1,4 +1,4 @@
-// Copyright 2016 Google Inc.
+// Copyright 2019 Google LLC.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -11,13 +11,16 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
+//
 
 syntax = "proto3";
 
 package google.iam.v1;
 
-import "google/api/annotations.proto";
+import "google/iam/v1/options.proto";
 import "google/iam/v1/policy.proto";
+import "google/api/annotations.proto";
+import "google/api/client.proto";
 
 option cc_enable_arenas = true;
 option csharp_namespace = "Google.Cloud.Iam.V1";
@@ -25,7 +28,7 @@ option go_package = "google.golang.org/genproto/googleapis/iam/v1;iam";
 option java_multiple_files = true;
 option java_outer_classname = "IamPolicyProto";
 option java_package = "com.google.iam.v1";
-
+option php_namespace = "Google\\Cloud\\Iam\\V1";
 
 // ## API Overview
 //
@@ -53,32 +56,46 @@ option java_package = "com.google.iam.v1";
 // are created and deleted implicitly with the resources to which they are
 // attached.
 service IAMPolicy {
+  option (google.api.default_host) = "iam-meta-api.googleapis.com";
+
   // Sets the access control policy on the specified resource. Replaces any
   // existing policy.
   rpc SetIamPolicy(SetIamPolicyRequest) returns (Policy) {
-    option (google.api.http) = { post: "/v1/{resource=**}:setIamPolicy" body: "*" };
+    option (google.api.http) = {
+      post: "/v1/{resource=**}:setIamPolicy"
+      body: "*"
+    };
   }
 
   // Gets the access control policy for a resource.
   // Returns an empty policy if the resource exists and does not have a policy
   // set.
   rpc GetIamPolicy(GetIamPolicyRequest) returns (Policy) {
-    option (google.api.http) = { post: "/v1/{resource=**}:getIamPolicy" body: "*" };
+    option (google.api.http) = {
+      post: "/v1/{resource=**}:getIamPolicy"
+      body: "*"
+    };
   }
 
   // Returns permissions that a caller has on the specified resource.
   // If the resource does not exist, this will return an empty set of
   // permissions, not a NOT_FOUND error.
+  //
+  // Note: This operation is designed to be used for building permission-aware
+  // UIs and command-line tools, not for authorization checking. This operation
+  // may "fail open" without warning.
   rpc TestIamPermissions(TestIamPermissionsRequest) returns (TestIamPermissionsResponse) {
-    option (google.api.http) = { post: "/v1/{resource=**}:testIamPermissions" body: "*" };
+    option (google.api.http) = {
+      post: "/v1/{resource=**}:testIamPermissions"
+      body: "*"
+    };
   }
 }
 
 // Request message for `SetIamPolicy` method.
 message SetIamPolicyRequest {
   // REQUIRED: The resource for which the policy is being specified.
-  // `resource` is usually specified as a path. For example, a Project
-  // resource is specified as `projects/{project}`.
+  // See the operation documentation for the appropriate value for this field.
   string resource = 1;
 
   // REQUIRED: The complete policy to be applied to the `resource`. The size of
@@ -91,16 +108,18 @@ message SetIamPolicyRequest {
 // Request message for `GetIamPolicy` method.
 message GetIamPolicyRequest {
   // REQUIRED: The resource for which the policy is being requested.
-  // `resource` is usually specified as a path. For example, a Project
-  // resource is specified as `projects/{project}`.
+  // See the operation documentation for the appropriate value for this field.
   string resource = 1;
+
+  // OPTIONAL: A `GetPolicyOptions` object for specifying options to
+  // `GetIamPolicy`. This field is only used by Cloud IAM.
+  google.iam.v1.GetPolicyOptions options = 2;
 }
 
 // Request message for `TestIamPermissions` method.
 message TestIamPermissionsRequest {
   // REQUIRED: The resource for which the policy detail is being requested.
-  // `resource` is usually specified as a path. For example, a Project
-  // resource is specified as `projects/{project}`.
+  // See the operation documentation for the appropriate value for this field.
   string resource = 1;
 
   // The set of permissions to check for the `resource`. Permissions with

--- a/protos/google/iam/v1/options.proto
+++ b/protos/google/iam/v1/options.proto
@@ -1,0 +1,37 @@
+// Copyright 2019 Google LLC.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+syntax = "proto3";
+
+package google.iam.v1;
+
+import "google/api/annotations.proto";
+
+option cc_enable_arenas = true;
+option csharp_namespace = "Google.Cloud.Iam.V1";
+option go_package = "google.golang.org/genproto/googleapis/iam/v1;iam";
+option java_multiple_files = true;
+option java_outer_classname = "OptionsProto";
+option java_package = "com.google.iam.v1";
+option php_namespace = "Google\\Cloud\\Iam\\V1";
+
+// Encapsulates settings provided to GetIamPolicy.
+message GetPolicyOptions {
+  // Optional. The policy format version to be returned.
+  // Acceptable values are 0 and 1.
+  // If the value is 0, or the field is omitted, policy format version 1 will be
+  // returned.
+  int32 requested_policy_version = 1;
+}

--- a/protos/google/iam/v1/policy.proto
+++ b/protos/google/iam/v1/policy.proto
@@ -1,4 +1,4 @@
-// Copyright 2016 Google Inc.
+// Copyright 2019 Google LLC.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -11,11 +11,13 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
+//
 
 syntax = "proto3";
 
 package google.iam.v1;
 
+import "google/type/expr.proto";
 import "google/api/annotations.proto";
 
 option cc_enable_arenas = true;
@@ -24,18 +26,18 @@ option go_package = "google.golang.org/genproto/googleapis/iam/v1;iam";
 option java_multiple_files = true;
 option java_outer_classname = "PolicyProto";
 option java_package = "com.google.iam.v1";
-
+option php_namespace = "Google\\Cloud\\Iam\\V1";
 
 // Defines an Identity and Access Management (IAM) policy. It is used to
 // specify access control policies for Cloud Platform resources.
 //
 //
-// A `Policy` consists of a list of `bindings`. A `Binding` binds a list of
+// A `Policy` consists of a list of `bindings`. A `binding` binds a list of
 // `members` to a `role`, where the members can be user accounts, Google groups,
 // Google domains, and service accounts. A `role` is a named list of permissions
 // defined by IAM.
 //
-// **Example**
+// **JSON Example**
 //
 //     {
 //       "bindings": [
@@ -45,7 +47,7 @@ option java_package = "com.google.iam.v1";
 //             "user:mike@example.com",
 //             "group:admins@example.com",
 //             "domain:google.com",
-//             "serviceAccount:my-other-app@appspot.gserviceaccount.com",
+//             "serviceAccount:my-other-app@appspot.gserviceaccount.com"
 //           ]
 //         },
 //         {
@@ -55,14 +57,27 @@ option java_package = "com.google.iam.v1";
 //       ]
 //     }
 //
+// **YAML Example**
+//
+//     bindings:
+//     - members:
+//       - user:mike@example.com
+//       - group:admins@example.com
+//       - domain:google.com
+//       - serviceAccount:my-other-app@appspot.gserviceaccount.com
+//       role: roles/owner
+//     - members:
+//       - user:sean@example.com
+//       role: roles/viewer
+//
+//
 // For a description of IAM and its features, see the
-// [IAM developer's guide](https://cloud.google.com/iam).
+// [IAM developer's guide](https://cloud.google.com/iam/docs).
 message Policy {
-  // Version of the `Policy`. The default version is 0.
+  // Deprecated.
   int32 version = 1;
 
   // Associates a list of `members` to a `role`.
-  // Multiple `bindings` must not be specified for the same `role`.
   // `bindings` with no members will result in an error.
   repeated Binding bindings = 4;
 
@@ -75,7 +90,7 @@ message Policy {
   // ensure that their change will be applied to the same version of the policy.
   //
   // If no `etag` is provided in the call to `setIamPolicy`, then the existing
-  // policy is overwritten blindly.
+  // policy is overwritten.
   bytes etag = 3;
 }
 
@@ -83,7 +98,6 @@ message Policy {
 message Binding {
   // Role that is assigned to `members`.
   // For example, `roles/viewer`, `roles/editor`, or `roles/owner`.
-  // Required
   string role = 1;
 
   // Specifies the identities requesting access for a Cloud Platform resource.
@@ -96,7 +110,7 @@ message Binding {
   //    who is authenticated with a Google account or a service account.
   //
   // * `user:{emailid}`: An email address that represents a specific Google
-  //    account. For example, `alice@gmail.com` or `joe@example.com`.
+  //    account. For example, `alice@example.com` .
   //
   //
   // * `serviceAccount:{emailid}`: An email address that represents a service
@@ -105,17 +119,27 @@ message Binding {
   // * `group:{emailid}`: An email address that represents a Google group.
   //    For example, `admins@example.com`.
   //
-  // * `domain:{domain}`: A Google Apps domain name that represents all the
+  //
+  // * `domain:{domain}`: The G Suite domain (primary) that represents all the
   //    users of that domain. For example, `google.com` or `example.com`.
   //
   //
   repeated string members = 2;
+
+  // The condition that is associated with this binding.
+  // NOTE: An unsatisfied condition will not allow user access via current
+  // binding. Different bindings, including their conditions, are examined
+  // independently.
+  google.type.Expr condition = 3;
 }
 
 // The difference delta between two policies.
 message PolicyDelta {
   // The delta for Bindings between two policies.
   repeated BindingDelta binding_deltas = 1;
+
+  // The delta for AuditConfigs between two policies.
+  repeated AuditConfigDelta audit_config_deltas = 2;
 }
 
 // One delta entry for Binding. Each individual change (only one member in each
@@ -146,4 +170,44 @@ message BindingDelta {
   // Follows the same format of Binding.members.
   // Required
   string member = 3;
+
+  // The condition that is associated with this binding. This field is logged
+  // only for Cloud Audit Logging.
+  google.type.Expr condition = 4;
+}
+
+// One delta entry for AuditConfig. Each individual change (only one
+// exempted_member in each entry) to a AuditConfig will be a separate entry.
+message AuditConfigDelta {
+  // The type of action performed on an audit configuration in a policy.
+  enum Action {
+    // Unspecified.
+    ACTION_UNSPECIFIED = 0;
+
+    // Addition of an audit configuration.
+    ADD = 1;
+
+    // Removal of an audit configuration.
+    REMOVE = 2;
+  }
+
+  // The action that was performed on an audit configuration in a policy.
+  // Required
+  Action action = 1;
+
+  // Specifies a service that was configured for Cloud Audit Logging.
+  // For example, `storage.googleapis.com`, `cloudsql.googleapis.com`.
+  // `allServices` is a special value that covers all services.
+  // Required
+  string service = 2;
+
+  // A single identity that is exempted from "data access" audit
+  // logging for the `service` specified above.
+  // Follows the same format of Binding.members.
+  string exempted_member = 3;
+
+  // Specifies the log_type that was be enabled. ADMIN_ACTIVITY is always
+  // enabled, and cannot be configured.
+  // Required
+  string log_type = 4;
 }

--- a/protos/google/type/expr.proto
+++ b/protos/google/type/expr.proto
@@ -1,0 +1,52 @@
+// Copyright 2019 Google LLC.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+syntax = "proto3";
+
+package google.type;
+
+option go_package = "google.golang.org/genproto/googleapis/type/expr;expr";
+option java_multiple_files = true;
+option java_outer_classname = "ExprProto";
+option java_package = "com.google.type";
+option objc_class_prefix = "GTP";
+
+
+// Represents an expression text. Example:
+//
+//     title: "User account presence"
+//     description: "Determines whether the request has a user account"
+//     expression: "size(request.user) > 0"
+message Expr {
+  // Textual representation of an expression in
+  // Common Expression Language syntax.
+  //
+  // The application context of the containing message determines which
+  // well-known feature set of CEL is supported.
+  string expression = 1;
+
+  // An optional title for the expression, i.e. a short string describing
+  // its purpose. This can be used e.g. in UIs which allow to enter the
+  // expression.
+  string title = 2;
+
+  // An optional description of the expression. This is a longer text which
+  // describes the expression, e.g. when hovered over it in a UI.
+  string description = 3;
+
+  // An optional string indicating the location of the expression for error
+  // reporting, e.g. a file name and a position in the file.
+  string location = 4;
+}

--- a/samples/system-test/subscriptions.test.js
+++ b/samples/system-test/subscriptions.test.js
@@ -228,10 +228,12 @@ describe('subscriptions', () => {
       {
         role: `roles/pubsub.editor`,
         members: [`group:cloud-logs@google.com`],
+        condition: null,
       },
       {
         role: `roles/pubsub.viewer`,
         members: [`allUsers`],
+        condition: null,
       },
     ]);
   });

--- a/samples/system-test/topics.test.js
+++ b/samples/system-test/topics.test.js
@@ -192,10 +192,12 @@ describe('topics', () => {
       {
         role: `roles/pubsub.editor`,
         members: [`group:cloud-logs@google.com`],
+        condition: null,
       },
       {
         role: `roles/pubsub.viewer`,
         members: [`allUsers`],
+        condition: null,
       },
     ]);
   });

--- a/system-test/pubsub.ts
+++ b/system-test/pubsub.ts
@@ -632,7 +632,10 @@ describe('pubsub', () => {
         policy,
         (err: ServiceError | null, newPolicy?: Policy | null) => {
           assert.ifError(err);
-          assert.deepStrictEqual(newPolicy!.bindings, policy.bindings);
+          const expectedBindings = policy.bindings.map(binding =>
+            Object.assign({condition: null}, binding)
+          );
+          assert.deepStrictEqual(newPolicy!.bindings, expectedBindings);
           done();
         }
       );


### PR DESCRIPTION
One consequence of #730 is that it will take up to date protos for IAM. Normally, this should not be an issue, but seems there was a slight change in the return value of setting IAM policy (added `condition: null` to the result). In this PR I'm updating the protos, the generated `.d.ts` files for IAM, and system/sample tests.

- [x] Tests and linter pass
- [x] Code coverage does not decrease (if any source code was changed)
- [x] Appropriate docs were updated (if necessary)
