### PR TITLE
docs: update publish sample's rpc timeout settings

### DIFF
--- a/samples/topics.js
+++ b/samples/topics.js
@@ -218,9 +218,9 @@ async function publishWithRetrySettings(projectId, topicName, data) {
       initialRetryDelayMillis: 100,
       retryDelayMultiplier: 1.3,
       maxRetryDelayMillis: 60000,
-      initialRpcTimeoutMillis: 12000,
+      initialRpcTimeoutMillis: 5000,
       rpcTimeoutMultiplier: 1.0,
-      maxRpcTimeoutMillis: 30000,
+      maxRpcTimeoutMillis: 600000,
       totalTimeoutMillis: 600000,
     },
   };


### PR DESCRIPTION
The current settings for RPC timeouts sample don't work. After discussion with @anguillanneuf @kir-titievsky @kamalaboulhosn, we decided to change the settings to the following:

* Initial RPC timeout: 5s (5000 ms)
* Max RPC timeout: 10m (600000 ms)

Will be filing a separate PR to update the defaults in the client library as well.