### PR TITLE
chore(deps): update dependency google-gax to ^1.5.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -62,7 +62,7 @@
     "async-each": "^1.0.1",
     "extend": "^3.0.2",
     "google-auth-library": "^5.0.0",
-    "google-gax": "^1.0.0",
+    "google-gax": "^1.5.2",
     "is-stream-ended": "^0.1.4",
     "lodash.snakecase": "^4.1.1",
     "p-defer": "^3.0.0",


### PR DESCRIPTION
Folks in #739 might be using an old version of `google-gax`. Let's explicitly bump the dependency then.

- [x] Tests and linter pass
- [x] Code coverage does not decrease (if any source code was changed)
- [x] Appropriate docs were updated (if necessary)
