### PR TITLE
fix(deps): remove direct dependency on @grpc/grpc-js

### DIFF
--- a/package.json
+++ b/package.json
@@ -54,7 +54,6 @@
     "@google-cloud/precise-date": "^1.0.0",
     "@google-cloud/projectify": "^1.0.0",
     "@google-cloud/promisify": "^1.0.0",
-    "@grpc/grpc-js": "^0.6.6",
     "@sindresorhus/is": "^1.0.0",
     "@types/duplexify": "^3.6.0",
     "@types/long": "^4.0.0",


### PR DESCRIPTION
I think we only pulled this in for TypeScript types, not sure if we still need it? Ideally we would get rid of it since we're going to put a hard pin on grpc for the future.