### PR TITLE
fix(docs): add documentation about running C++ gRPC bindings

### DIFF
--- a/.readme-partials.yml
+++ b/.readme-partials.yml
@@ -11,8 +11,8 @@ introduction: |-
 body: |-
         ## Running gRPC C++ bindings
 
-        For some workflows and environments (see: [#770](https://github.com/googleapis/nodejs-pubsub/issues/770)), we have found
-        that running the native gRPC bindings, rather than the default `@grpc/grpc-js`, can be more stable.
+        For some workflows and environments it might make sense to use the C++ gRPC implementation,
+        instead of the default one (see: [#770](https://github.com/googleapis/nodejs-pubsub/issues/770)):
 
         To configure `@google-cloud/pubsub` to use an alternative `grpc` transport:
 

--- a/.readme-partials.yml
+++ b/.readme-partials.yml
@@ -8,3 +8,19 @@ introduction: |-
         [Pub/Sub quickstart](https://cloud.google.com/pubsub/docs/quickstart-client-libraries),
         [publisher](https://cloud.google.com/pubsub/docs/publisher), and [subscriber](https://cloud.google.com/pubsub/docs/subscriber)
         guides.
+body: |-
+        ## Running gRPC C++ bindings
+
+        For some workflows and environments (see: [#770](https://github.com/googleapis/nodejs-pubsub/issues/770)), we have found
+        that running the native gRPC bindings, rather than the default `@grpc/grpc-js`, can be more stable.
+
+        To configure `@google-cloud/pubsub` to use an alternative `grpc` transport:
+
+        1. `npm install grpc`, adding `grpc` as a dependency.
+        1. instantiate `@google-cloud/pubsub` with `grpc`:
+
+           ```js
+           const {PubSub} = require('@google-cloud/pubsub');
+           const grpc = require('grpc');
+           const pubsub = new PubSub({grpc});
+           ```

--- a/README.md
+++ b/README.md
@@ -81,8 +81,8 @@ async function quickstart(
 ```
 ## Running gRPC C++ bindings
 
-For some workflows and environments (see: [#770](https://github.com/googleapis/nodejs-pubsub/issues/770)), we have found
-that running the native gRPC bindings, rather than the default `@grpc/grpc-js`, can be more stable.
+For some workflows and environments it might make sense to use the C++ gRPC implementation,
+instead of the default one (see: [#770](https://github.com/googleapis/nodejs-pubsub/issues/770)):
 
 To configure `@google-cloud/pubsub` to use an alternative `grpc` transport:
 

--- a/README.md
+++ b/README.md
@@ -79,7 +79,21 @@ async function quickstart(
 }
 
 ```
+## Running gRPC C++ bindings
 
+For some workflows and environments (see: [#770](https://github.com/googleapis/nodejs-pubsub/issues/770)), we have found
+that running the native gRPC bindings, rather than the default `@grpc/grpc-js`, can be more stable.
+
+To configure `@google-cloud/pubsub` to use an alternative `grpc` transport:
+
+1. `npm install grpc`, adding `grpc` as a dependency.
+1. instantiate `@google-cloud/pubsub` with `grpc`:
+
+   ```js
+   const {PubSub} = require('@google-cloud/pubsub');
+   const grpc = require('grpc');
+   const pubsub = new PubSub({grpc});
+   ```
 
 
 ## Samples


### PR DESCRIPTION
Updates documentation documenting how one goes about swapping in the `grpc` dependency, rather than `@grpc/grpc-js`. We've been finding for some workloads, `grpc` can be a more stable choice.

fixes #781 
see #770 