### PR TITLE
process: testing pre-release version of gax with new @grpc/grpc-js

### DIFF
--- a/package.json
+++ b/package.json
@@ -59,7 +59,7 @@
     "async-each": "^1.0.1",
     "extend": "^3.0.2",
     "google-auth-library": "^5.5.0",
-    "google-gax": "^1.7.5",
+    "google-gax": "^1.11.2-pre",
     "is-stream-ended": "^0.1.4",
     "lodash.snakecase": "^4.1.1",
     "p-defer": "^3.0.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@google-cloud/pubsub",
   "description": "Cloud Pub/Sub Client Library for Node.js",
-  "version": "1.1.5",
+  "version": "1.1.6-beta.0",
   "license": "Apache-2.0",
   "author": "Google Inc.",
   "engines": {


### PR DESCRIPTION
We are testing a pre-release version of `@google-cloud/pubsub` with a few folks, it floats a new version of `@grpc/grpc-js` which we believe addresses some memory issues:

Refs: https://github.com/grpc/grpc-node/issues/1085


---

@schmidt-sebastian perhaps we could float a similar patch for firestore and see if it addresses https://github.com/googleapis/nodejs-firestore/issues/768.

*Note: this is here to track a pre-release, we should not merge.*