### PR TITLE
test(system): fix snapshot tests

### DIFF
--- a/samples/system-test/subscriptions.test.js
+++ b/samples/system-test/subscriptions.test.js
@@ -27,7 +27,8 @@ const execPromise = cmd =>
     cp.exec(cmd, {encoding: 'utf-8'}, (err, stdout, stderr) => {
       if (err) {
         err.stderr = stderr;
-        return reject(err);
+        reject(err);
+        return;
       }
       resolve(stdout);
     });
@@ -49,21 +50,22 @@ describe('subscriptions', () => {
   const fullSubscriptionNameFour = `projects/${projectId}/subscriptions/${subscriptionNameFour}`;
   const cmd = `node subscriptions.js`;
 
-  before(async () => {
-    await Promise.all([
+  before(() => {
+    return Promise.all([
       pubsub.createTopic(topicNameOne),
       pubsub.createTopic(topicNameTwo),
     ]);
   });
 
-  after(async () => {
-    const rm = obj => obj.delete().catch(console.error);
-    await rm(pubsub.subscription(subscriptionNameOne));
-    await rm(pubsub.subscription(subscriptionNameTwo));
-    await rm(pubsub.subscription(subscriptionNameThree));
-    await rm(pubsub.subscription(subscriptionNameFour));
-    await rm(pubsub.topic(topicNameOne));
-    await rm(pubsub.topic(topicNameTwo));
+  after(() => {
+    return Promise.all([
+      pubsub.subscription(subscriptionNameOne).delete(),
+      pubsub.subscription(subscriptionNameTwo).delete(),
+      pubsub.subscription(subscriptionNameThree).delete(),
+      pubsub.subscription(subscriptionNameFour).delete(),
+      pubsub.topic(topicNameOne).delete(),
+      pubsub.topic(topicNameTwo).delete(),
+    ]).catch(console.error);
   });
 
   it('should create a subscription', async () => {

--- a/samples/system-test/topics.test.js
+++ b/samples/system-test/topics.test.js
@@ -50,12 +50,12 @@ describe('topics', () => {
   });
 
   // Helper function to pull one message.
-  // Times out after 10 seconds.
+  // Times out after 55 seconds.
   const _pullOneMessage = subscriptionObj => {
     return new Promise((resolve, reject) => {
       const timeoutHandler = setTimeout(() => {
         reject(new Error(`_pullOneMessage timed out`));
-      }, 10000);
+      }, 55000);
 
       subscriptionObj.once('error', reject).once('message', message => {
         message.ack();

--- a/samples/system-test/topics.test.js
+++ b/samples/system-test/topics.test.js
@@ -59,13 +59,11 @@ describe('topics', () => {
         return reject(new Error(`_pullOneMessage timed out`));
       }, timeout);
 
-      subscriptionObj
-        .once('error', reject)
-        .once('message', received => {
-          received.ack();
-          clearTimeout(timeoutHandler);
-          return resolve(message);
-        });
+      subscriptionObj.once('error', reject).once('message', message => {
+        message.ack();
+        clearTimeout(timeoutHandler);
+        return resolve(message);
+      });
     });
   };
 

--- a/system-test/pubsub.ts
+++ b/system-test/pubsub.ts
@@ -709,46 +709,44 @@ describe('pubsub', () => {
 
     describe('seeking', () => {
       let subscription: Subscription;
+      let snapshot: Snapshot;
       let messageId: string;
       const snapshotName = generateSnapshotName();
 
       beforeEach(async () => {
         subscription = topic.subscription(generateSubName());
-        await subscription.create();
-        messageId = await topic.publish(Buffer.from('Hello, world!'));
-        // The first call to `createSnapshot` consistently fails,
-        // see: https://github.com/googleapis/nodejs-pubsub/issues/821
-        try {
-          await subscription.createSnapshot(snapshotName);
-        } catch (err) {
-          console.warn(err.message);
-        }
+        snapshot = subscription.snapshot(generateSnapshotName());
+        
+        return subscription
+          .create()
+          .then(() => {
+            return snapshot.create();
+          })
+          .then(() => {
+            return topic.publish(Buffer.from('Hello, world!'));
+          })
+          .then(_messageId => {
+            messageId = _messageId;
+          });
       });
 
       it('should seek to a snapshot', done => {
-        subscription.createSnapshot(snapshotName, (err, snapshot) => {
-          assert.ifError(err);
+        let messageCount = 0;
 
-          let messageCount = 0;
+        subscription.on('error', done);
+        subscription.on('message', message => {
+          if (message.id !== messageId) {
+            return;
+          }
+          message.ack();
 
-          subscription.on('error', done);
-          subscription.on('message', message => {
-            if (message.id !== messageId) {
-              return;
-            }
+          if (++messageCount === 1) {
+            snapshot!.seek(assert.ifError);
+            return;
+          }
 
-            message.ack();
-
-            if (++messageCount === 1) {
-              snapshot!.seek(err => {
-                assert.ifError(err);
-              });
-              return;
-            }
-
-            assert.strictEqual(messageCount, 2);
-            subscription.close(done);
-          });
+          assert.strictEqual(messageCount, 2);
+          subscription.close(done);
         });
       });
 

--- a/system-test/pubsub.ts
+++ b/system-test/pubsub.ts
@@ -716,7 +716,7 @@ describe('pubsub', () => {
       beforeEach(async () => {
         subscription = topic.subscription(generateSubName());
         snapshot = subscription.snapshot(generateSnapshotName());
-        
+
         return subscription
           .create()
           .then(() => {


### PR DESCRIPTION
RE: #826 (not sure it's a fix yet)
Fixes: #821 

This test was failing locally for me:

```
  1) pubsub
       Snapshot
         seeking
           should seek to a snapshot:
     Uncaught AssertionError [ERR_ASSERTION]: ifError got unwanted exception: 6 ALREADY_EXISTS: Resource already exists in the project (resource=gcloud-tests-snapshot-6dc2ee71-1574603452115).
      at subscription.createSnapshot (system-test/pubsub.ts:730:18)
      at Immediate.request [as _onImmediate] (src/subscription.ts:464:11)
      at Object.callErrorFromStatus (node_modules/@grpc/grpc-js/build/src/call.js:30:26)
      at Http2CallStream.call.on (node_modules/@grpc/grpc-js/build/src/client.js:96:33)
      at process.nextTick (node_modules/@grpc/grpc-js/build/src/call-stream.js:75:22)
      at process.internalTickCallback (internal/process/next_tick.js:70:11)
```

This throws back to changes made in #815 and #821. I changed the logic to work more like I think we were expecting.

The tests in the PR continue to fail as noted in #826. Unfortunately, I'm not sure how to address that yet.