### PR TITLE
refactor: drop usage of is

### DIFF
--- a/package.json
+++ b/package.json
@@ -52,7 +52,6 @@
     "@google-cloud/precise-date": "^1.0.0",
     "@google-cloud/projectify": "^1.0.0",
     "@google-cloud/promisify": "^1.0.0",
-    "@sindresorhus/is": "^1.0.0",
     "@types/duplexify": "^3.6.0",
     "@types/long": "^4.0.0",
     "arrify": "^2.0.0",

--- a/src/pubsub.ts
+++ b/src/pubsub.ts
@@ -17,7 +17,6 @@
 import {paginator} from '@google-cloud/paginator';
 import {replaceProjectIdToken} from '@google-cloud/projectify';
 import {promisifyAll} from '@google-cloud/promisify';
-import is from '@sindresorhus/is';
 import * as extend from 'extend';
 import {GoogleAuth} from 'google-auth-library';
 import * as gax from 'google-gax';
@@ -378,10 +377,10 @@ export class PubSub {
     optionsOrCallback?: CreateSubscriptionOptions | CreateSubscriptionCallback,
     callback?: CreateSubscriptionCallback
   ): Promise<CreateSubscriptionResponse> | void {
-    if (!is.string(topic) && !(topic instanceof Topic)) {
+    if (typeof topic !== 'string' && !(topic instanceof Topic)) {
       throw new Error('A Topic is required for a new subscription.');
     }
-    if (!is.string(name)) {
+    if (typeof name !== 'string') {
       throw new Error('A subscription name is required.');
     }
     if (typeof topic === 'string') {
@@ -975,7 +974,7 @@ export class PubSub {
    * const snapshot = pubsub.snapshot('my-snapshot');
    */
   snapshot(name: string): Snapshot {
-    if (!is.string(name)) {
+    if (typeof name !== 'string') {
       throw new Error('You must supply a valid name for the snapshot.');
     }
     return new Snapshot(this, name);

--- a/src/subscription.ts
+++ b/src/subscription.ts
@@ -15,7 +15,6 @@
  */
 
 import {promisifyAll} from '@google-cloud/promisify';
-import is from '@sindresorhus/is';
 import {EventEmitter} from 'events';
 import * as extend from 'extend';
 import {CallOptions} from 'google-gax';
@@ -441,7 +440,7 @@ export class Subscription extends EventEmitter {
     optsOrCallback?: CallOptions | CreateSnapshotCallback,
     callback?: CreateSnapshotCallback
   ): void | Promise<CreateSnapshotResponse> {
-    if (!is.string(name)) {
+    if (typeof name !== 'string') {
       throw new Error('A name is required to create a snapshot.');
     }
     const gaxOpts = typeof optsOrCallback === 'object' ? optsOrCallback : {};
@@ -881,7 +880,7 @@ export class Subscription extends EventEmitter {
 
     if (typeof snapshot === 'string') {
       reqOpts.snapshot = Snapshot.formatName_(this.pubsub.projectId, snapshot);
-    } else if (is.date(snapshot)) {
+    } else if (Object.prototype.toString.call(snapshot) === '[object Date]') {
       reqOpts.time = snapshot as google.protobuf.ITimestamp;
     } else {
       throw new Error('Either a snapshot name or Date is needed to seek to.');

--- a/src/topic.ts
+++ b/src/topic.ts
@@ -16,7 +16,6 @@
 
 import {paginator} from '@google-cloud/paginator';
 import {promisifyAll} from '@google-cloud/promisify';
-import is from '@sindresorhus/is';
 import {CallOptions} from 'google-gax';
 
 import {google} from '../proto/pubsub';
@@ -711,7 +710,7 @@ export class Topic {
     attrsOrCb?: Attributes | PublishCallback,
     callback?: PublishCallback
   ): Promise<string> | void {
-    if (!is.object(json)) {
+    if (!json || typeof json !== 'object') {
       throw new Error('First parameter should be an object.');
     }
     const attributes = typeof attrsOrCb === 'object' ? attrsOrCb : {};
@@ -779,7 +778,7 @@ export class Topic {
   ): Promise<[string]> | void {
     message = Object.assign({}, message);
 
-    if (is.object(message.json)) {
+    if (message.json && typeof message.json === 'object') {
       message.data = Buffer.from(JSON.stringify(message.json));
       delete message.json;
     }


### PR DESCRIPTION
The `is` module was creating TypeScript compilation errors.  Just getting rid of it.