### PR TITLE
chore: revert the linkinator change from refactor-samples so that it checks those docs again

### DIFF
--- a/linkinator.config.json
+++ b/linkinator.config.json
@@ -2,7 +2,6 @@
   "recurse": true,
   "skip": [
     "https://codecov.io/gh/googleapis/",
-    "www.googleapis.com",
-    "https://github.com/googleapis/nodejs-pubsub/blob/master/samples/"
+    "www.googleapis.com"
   ]
 }


### PR DESCRIPTION
This is a follow-on to this PR: https://github.com/googleapis/nodejs-pubsub/pull/844

This finishes resolving the chicken and egg problem with the linkinator errors from the README updates.
