### PR TITLE
chore: remove temporary linkinator exception from PR #856

### DIFF
--- a/linkinator.config.json
+++ b/linkinator.config.json
@@ -2,7 +2,6 @@
   "recurse": true,
   "skip": [
     "https://codecov.io/gh/googleapis/",
-    "www.googleapis.com",
-    "https://github.com/googleapis/nodejs-pubsub/"
+    "www.googleapis.com"
   ]
 }


### PR DESCRIPTION
Removes the temporary linkinator exception required to get this through: https://github.com/googleapis/nodejs-pubsub/pull/856
