### PR TITLE
fix: send the ITimestamp protobuf to Pub/Sub for seeking, not JavaScript Date()

### DIFF
--- a/src/subscription.ts
+++ b/src/subscription.ts
@@ -895,7 +895,7 @@ export class Subscription extends EventEmitter {
       const dateMillis = (snapshot as Date).getTime();
       reqOpts.time = {
         seconds: Math.floor(dateMillis / 1000),
-        nanos: Math.floor(dateMillis % 1000) * 1000
+        nanos: Math.floor(dateMillis % 1000) * 1000,
       };
     } else {
       throw new Error('Either a snapshot name or Date is needed to seek to.');

--- a/src/subscription.ts
+++ b/src/subscription.ts
@@ -892,7 +892,11 @@ export class Subscription extends EventEmitter {
     if (typeof snapshot === 'string') {
       reqOpts.snapshot = Snapshot.formatName_(this.pubsub.projectId, snapshot);
     } else if (Object.prototype.toString.call(snapshot) === '[object Date]') {
-      reqOpts.time = snapshot as google.protobuf.ITimestamp;
+      const dateMillis = (snapshot as Date).getTime();
+      reqOpts.time = {
+        seconds: Math.floor(dateMillis / 1000),
+        nanos: Math.floor(dateMillis % 1000) * 1000
+      };
     } else {
       throw new Error('Either a snapshot name or Date is needed to seek to.');
     }

--- a/system-test/pubsub.ts
+++ b/system-test/pubsub.ts
@@ -862,6 +862,27 @@ describe('pubsub', () => {
           subscription.close(done);
         });
       });
+
+      it('should seek to a future date (purge)', done => {
+        const testText = 'Oh no!';
+
+        // Forward-seek to remove any messages from the queue (those were
+        // placed there in before()).
+        //
+        // We... probably won't be using this in 3000?
+        subscription.seek(new Date('3000-01-01')).then(() => {
+          // Drop a second message and make sure it's the right ID.
+          return topic.publish(Buffer.from(testText));
+        }).then(() => {
+          subscription.on('error', done);
+          subscription.on('message', message => {
+            // If we get the default message from before() then this fails.
+            assert.equal(message.data.toString(), testText);
+            message.ack();
+            subscription.close(done);
+          });
+        });
+      });
     });
   });
 });

--- a/system-test/pubsub.ts
+++ b/system-test/pubsub.ts
@@ -870,18 +870,21 @@ describe('pubsub', () => {
         // placed there in before()).
         //
         // We... probably won't be using this in 3000?
-        subscription.seek(new Date('3000-01-01')).then(() => {
-          // Drop a second message and make sure it's the right ID.
-          return topic.publish(Buffer.from(testText));
-        }).then(() => {
-          subscription.on('error', done);
-          subscription.on('message', message => {
-            // If we get the default message from before() then this fails.
-            assert.equal(message.data.toString(), testText);
-            message.ack();
-            subscription.close(done);
+        subscription
+          .seek(new Date('3000-01-01'))
+          .then(() => {
+            // Drop a second message and make sure it's the right ID.
+            return topic.publish(Buffer.from(testText));
+          })
+          .then(() => {
+            subscription.on('error', done);
+            subscription.on('message', message => {
+              // If we get the default message from before() then this fails.
+              assert.equal(message.data.toString(), testText);
+              message.ack();
+              subscription.close(done);
+            });
           });
-        });
       });
     });
   });

--- a/test/subscription.ts
+++ b/test/subscription.ts
@@ -884,7 +884,13 @@ describe('Subscription', () => {
 
     it('should optionally accept a Date object', done => {
       const date = new Date();
-      const reqOpts = {subscription: SUB_FULL_NAME, time: date};
+      const reqOpts = {
+        subscription: SUB_FULL_NAME,
+        time: {
+          seconds: Math.floor(date.getTime() / 1000),
+          nanos: Math.floor(date.getTime() % 1000) * 1000
+        }
+      };
       subscription.request = (config: RequestConfig) => {
         assert.deepStrictEqual(config.reqOpts, reqOpts);
         done();

--- a/test/subscription.ts
+++ b/test/subscription.ts
@@ -888,8 +888,8 @@ describe('Subscription', () => {
         subscription: SUB_FULL_NAME,
         time: {
           seconds: Math.floor(date.getTime() / 1000),
-          nanos: Math.floor(date.getTime() % 1000) * 1000
-        }
+          nanos: Math.floor(date.getTime() % 1000) * 1000,
+        },
       };
       subscription.request = (config: RequestConfig) => {
         assert.deepStrictEqual(config.reqOpts, reqOpts);


### PR DESCRIPTION
This fixes a bug in the seek() method that prevented users from passing a date correctly. This is especially relevant for purging (seek to the future).

May relate: https://github.com/googleapis/nodejs-pubsub/issues/905
Related internally: 150712874
