### PR TITLE
docs: update site link for UpdateTopicRequest

### DIFF
--- a/src/topic.ts
+++ b/src/topic.ts
@@ -834,7 +834,7 @@ export class Topic {
   /**
    * Updates the topic.
    *
-   * @see [UpdateTopicRequest API Documentation]{@link https://cloud.google.com/pubsub/docs/reference/rest/v1/UpdateTopicRequest}
+   * @see [UpdateTopicRequest API Documentation]{@link https://cloud.google.com/pubsub/docs/reference/rpc/google.pubsub.v1#google.pubsub.v1.UpdateTopicRequest}
    *
    * @param {object} metadata The fields to update. This should be structured
    *     like a {@link


### PR DESCRIPTION
The old link wasn't valid anymore, I'm guessing due to an update to the docs site.
