### PR TITLE
fix: provide missing close() method in the generated gapic client

### DIFF
--- a/src/v1/publisher_client.js
+++ b/src/v1/publisher_client.js
@@ -219,6 +219,7 @@ class PublisherClient {
         : protos.google.pubsub.v1.Publisher,
       opts
     );
+    this.publisherStub = publisherStub;
 
     // Iterate over each of the methods that the service provides
     // and create an API call method for each.
@@ -1201,6 +1202,17 @@ class PublisherClient {
    */
   matchTopicFromTopicName(topicName) {
     return this._pathTemplates.topicPathTemplate.match(topicName).topic;
+  }
+
+  /**
+   * Terminate the GRPC channel and close the client.
+   *
+   * The client will no longer be usable and all future behavior is undefined.
+   */
+  close() {
+    return this.publisherStub.then(stub => {
+      stub.close();
+    });
   }
 }
 

--- a/src/v1/publisher_client.js
+++ b/src/v1/publisher_client.js
@@ -219,10 +219,11 @@ class PublisherClient {
         : protos.google.pubsub.v1.Publisher,
       opts
     );
-    this.publisherStub = publisherStub;
 
     // Iterate over each of the methods that the service provides
     // and create an API call method for each.
+    // note: editing generated code
+    this.publisherStub = publisherStub;
     const publisherStubMethods = [
       'createTopic',
       'updateTopic',
@@ -1172,6 +1173,18 @@ class PublisherClient {
   }
 
   /**
+   * Terminate the GRPC channel and close the client.
+   * note: editing generated code
+   *
+   * The client will no longer be usable and all future behavior is undefined.
+   */
+  close() {
+    return this.publisherStub.then(stub => {
+      stub.close();
+    });
+  }
+
+  /**
    * Parse the projectName from a project resource.
    *
    * @param {String} projectName
@@ -1202,17 +1215,6 @@ class PublisherClient {
    */
   matchTopicFromTopicName(topicName) {
     return this._pathTemplates.topicPathTemplate.match(topicName).topic;
-  }
-
-  /**
-   * Terminate the GRPC channel and close the client.
-   *
-   * The client will no longer be usable and all future behavior is undefined.
-   */
-  close() {
-    return this.publisherStub.then(stub => {
-      stub.close();
-    });
   }
 }
 

--- a/synth.py
+++ b/synth.py
@@ -37,6 +37,29 @@ s.replace("src/v1/subscriber_client.js",
           "    };\n"
           "\g<0>")
 
+# The JavaScript generator didn't implement close(). TypeScript gapic does,
+# so this should be removed when we merge that.
+s.replace("src/v1/publisher_client.js",
+          "   \* Parse the projectName from a project resource.\n",
+          "   * Terminate the GRPC channel and close the client.\n"
+          "   * note: editing generated code\n"
+          "   *\n"
+          "   * The client will no longer be usable and all future behavior is undefined.\n"
+          "   */\n"
+          "  close() {\n"
+          "    return this.publisherStub.then(stub => {\n"
+          "      stub.close();\n"
+          "    });\n"
+          "  }\n"
+          "  \n"
+          "  /**\n"
+          "  \g<0>")
+s.replace("src/v1/publisher_client.js",
+          "    const publisherStubMethods = \\[\n",
+          "    // note: editing generated code\n"
+          "    this.publisherStub = publisherStub;\n"
+          "    \g<0>")
+
 # Update path discovery due to build/ dir and TypeScript conversion.
 s.replace("src/v1/publisher_client.js", "../../package.json", "../../../package.json")
 s.replace("src/v1/subscriber_client.js", "../../package.json", "../../../package.json")

--- a/system-test/pubsub.ts
+++ b/system-test/pubsub.ts
@@ -888,4 +888,17 @@ describe('pubsub', () => {
       });
     });
   });
+
+  it('should allow closing of publisher clients', async () => {
+    // The full call stack of close() is tested in unit tests; this is mostly
+    // to verify that the close() method is actually there and doesn't error.
+    const localPubsub = new PubSub();
+
+    // Just use the client object to make sure it has opened a connection.
+    await pubsub.getTopics();
+
+    // Tell it to close, and validate that it's marked closed.
+    await localPubsub.close();
+    assert.strictEqual(localPubsub.isOpen, false);
+  });
 });


### PR DESCRIPTION
Fixes: https://github.com/googleapis/nodejs-pubsub/issues/937

The issue is that our TypeScript gapic generator provides a close() method, but the old JavaScript one doesn't seem to. So the close() feature addition was relying on some invalid typings. I've backported that for publisher client, and added a system-test that will hopefully catch future issues.

Going forward, the TypeScript gapic upgrade is definitely the right fix here, but that's also going to bump us up to Node 10+, so I want to fix this existing feature first.
