### PR TITLE
fix: add a close() method to the generated SubscriberClient for 1.x

### DIFF
--- a/src/v1/subscriber_client.js
+++ b/src/v1/subscriber_client.js
@@ -220,6 +220,8 @@ class SubscriberClient {
 
     // Iterate over each of the methods that the service provides
     // and create an API call method for each.
+    // note: editing generated code
+    this.subscriberStub = subscriberStub;
     const subscriberStubMethods = [
       'createSubscription',
       'getSubscription',
@@ -1855,6 +1857,18 @@ class SubscriberClient {
     return this._pathTemplates.topicPathTemplate.render({
       project: project,
       topic: topic,
+    });
+  }
+
+  /**
+   * Terminate the GRPC channel and close the client.
+   * note: editing generated code
+   *
+   * The client will no longer be usable and all future behavior is undefined.
+   */
+  close() {
+    return this.subscriberStub.then(stub => {
+      stub.close();
     });
   }
 

--- a/synth.py
+++ b/synth.py
@@ -62,6 +62,26 @@ s.replace("src/v1/publisher_client.js",
           "    // note: editing generated code\n"
           "    this.publisherStub = publisherStub;\n"
           "    \g<0>")
+s.replace("src/v1/subscriber_client.js",
+          "   \* Parse the projectName from a project resource.\n",
+          "   * Terminate the GRPC channel and close the client.\n"
+          "   * note: editing generated code\n"
+          "   *\n"
+          "   * The client will no longer be usable and all future behavior is undefined.\n"
+          "   */\n"
+          "  close() {\n"
+          "    return this.subscriberStub.then(stub => {\n"
+          "      stub.close();\n"
+          "    });\n"
+          "  }\n"
+          "  \n"
+          "  /**\n"
+          "  \g<0>")
+s.replace("src/v1/subscriber_client.js",
+          "    const subscriberStubMethods = \\[\n",
+          "    // note: editing generated code\n"
+          "    this.subscriberStub = subscriberStub;\n"
+          "    \g<0>")
 
 # Update path discovery due to build/ dir and TypeScript conversion.
 s.replace("src/v1/publisher_client.js", "../../package.json", "../../../package.json")

--- a/system-test/pubsub.ts
+++ b/system-test/pubsub.ts
@@ -901,4 +901,17 @@ describe('pubsub', () => {
     await localPubsub.close();
     assert.strictEqual(localPubsub.isOpen, false);
   });
+
+  it('should allow closing of subscriber clients', async () => {
+    // The full call stack of close() is tested in unit tests; this is mostly
+    // to verify that the close() method is actually there and doesn't error.
+    const localPubsub = new PubSub();
+
+    // Just use the client object to make sure it has opened a connection.
+    await pubsub.getSubscriptions();
+
+    // Tell it to close, and validate that it's marked closed.
+    await localPubsub.close();
+    assert.strictEqual(localPubsub.isOpen, false);
+  });
 });


### PR DESCRIPTION
Apparently the gapic generated SubscriberClient also doesn't have a `close()` method. This adds another synth.py hack and corresponding change in the .js file. Also a new system-test to catch subscribers specifically.

Follow-on fix for https://github.com/googleapis/nodejs-pubsub/issues/937

A proper fix is happening at https://github.com/googleapis/nodejs-pubsub/pull/923 but it will require bumping major versions, so I'm basically backporting this for 1.7.x.
