### PR TITLE
chore: release 1.7.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,14 @@
 
 [1]: https://www.npmjs.com/package/@google-cloud/pubsub?activeTab=versions
 
+### [1.7.2](https://www.github.com/googleapis/nodejs-pubsub/compare/v1.7.1...v1.7.2) (2020-04-08)
+
+This fix release was manually pushed to legacy-8.
+
+### Bug Fixes
+
+* add a close() method to the generated SubscriberClient for 1.x ([#937](https://github.com/googleapis/nodejs-pubsub/issues/937)) ([PR](https://github.com/googleapis/nodejs-pubsub/pull/948))
+
 ### [1.7.1](https://www.github.com/googleapis/nodejs-pubsub/compare/v1.7.0...v1.7.1) (2020-04-06)
 
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@google-cloud/pubsub",
   "description": "Cloud Pub/Sub Client Library for Node.js",
-  "version": "1.7.1",
+  "version": "1.7.2",
   "license": "Apache-2.0",
   "author": "Google Inc.",
   "engines": {

--- a/samples/package.json
+++ b/samples/package.json
@@ -14,7 +14,7 @@
     "test": "mocha system-test --timeout 600000"
   },
   "dependencies": {
-    "@google-cloud/pubsub": "^1.7.1"
+    "@google-cloud/pubsub": "^1.7.2"
   },
   "devDependencies": {
     "chai": "^4.2.0",


### PR DESCRIPTION
Beep boop!

Manual release on the legacy-8 branch.
