### PR TITLE
chore!: drop support for custom promises

### DIFF
--- a/src/iam.ts
+++ b/src/iam.ts
@@ -93,16 +93,11 @@ export type TestIamPermissionsCallback = ResourceCallback<
  * // subscription.iam
  */
 export class IAM {
-  // tslint:disable-next-line variable-name
-  Promise?: PromiseConstructor;
   pubsub: PubSub;
   request: typeof PubSub.prototype.request;
   id: string;
 
   constructor(pubsub: PubSub, id: string) {
-    if (pubsub.Promise) {
-      this.Promise = pubsub.Promise;
-    }
     this.pubsub = pubsub;
     this.request = pubsub.request.bind(pubsub);
     this.id = id;

--- a/src/publisher/index.ts
+++ b/src/publisher/index.ts
@@ -56,17 +56,11 @@ export const BATCH_LIMITS: BatchPublishOptions = {
  * @param {PublishOptions} [options] Configuration object.
  */
 export class Publisher {
-  // tslint:disable-next-line variable-name
-  Promise?: PromiseConstructor;
   topic: Topic;
   settings!: PublishOptions;
   queue: Queue;
   orderedQueues: Map<string, OrderedQueue>;
   constructor(topic: Topic, options?: PublishOptions) {
-    if (topic.Promise) {
-      this.Promise = topic.Promise;
-    }
-
     this.setOptions(options);
     this.topic = topic;
     this.queue = new Queue(this);

--- a/src/snapshot.ts
+++ b/src/snapshot.ts
@@ -103,13 +103,8 @@ export type SeekResponse = [google.pubsub.v1.ISeekResponse];
 export class Snapshot {
   parent: Subscription | PubSub;
   name: string;
-  // tslint:disable-next-line variable-name
-  Promise?: PromiseConstructor;
   metadata?: google.pubsub.v1.ISnapshot;
   constructor(parent: Subscription | PubSub, name: string) {
-    if (parent instanceof PubSub) {
-      this.Promise = parent.Promise;
-    }
     this.parent = parent;
     this.name = Snapshot.formatName_(parent.projectId, name);
   }

--- a/src/topic.ts
+++ b/src/topic.ts
@@ -100,8 +100,6 @@ export type MessageOptions = PubsubMessage & {json?: any};
  * const topic = pubsub.topic('ordered-topic', {enableMessageOrdering: true});
  */
 export class Topic {
-  // tslint:disable-next-line variable-name
-  Promise?: PromiseConstructor;
   name: string;
   parent: PubSub;
   pubsub: PubSub;
@@ -114,9 +112,6 @@ export class Topic {
   ) as () => ObjectStream<Subscription>;
 
   constructor(pubsub: PubSub, name: string, options?: PublishOptions) {
-    if (pubsub.Promise) {
-      this.Promise = pubsub.Promise;
-    }
     /**
      * The fully qualified name of this topic.
      * @name Topic#name

--- a/test/iam.ts
+++ b/test/iam.ts
@@ -37,7 +37,6 @@ describe('IAM', () => {
 
   const PUBSUB = ({
     options: {},
-    Promise: {},
     request: util.noop,
   } as {}) as PubSub;
   const ID = 'id';
@@ -53,10 +52,6 @@ describe('IAM', () => {
   });
 
   describe('initialization', () => {
-    it('should localize pubsub.Promise', () => {
-      assert.strictEqual(iam.Promise, PUBSUB.Promise);
-    });
-
     it('should localize pubsub', () => {
       assert.strictEqual(iam.pubsub, PUBSUB);
     });

--- a/test/publisher/index.ts
+++ b/test/publisher/index.ts
@@ -97,12 +97,6 @@ describe('Publisher', () => {
       assert(promisified);
     });
 
-    it('should localize Promise class if set', () => {
-      const t = {Promise} as Topic;
-      publisher = new Publisher(t);
-      assert.strictEqual(publisher.Promise, Promise);
-    });
-
     it('should capture user options', () => {
       const stub = sandbox.stub(Publisher.prototype, 'setOptions');
 

--- a/test/pubsub.ts
+++ b/test/pubsub.ts
@@ -151,7 +151,6 @@ describe('PubSub', () => {
   let pubsub: pubsubTypes.PubSub;
   const OPTIONS = {
     projectId: PROJECT_ID,
-    promise: {},
   } as pubsubTypes.ClientConfig;
 
   const PUBSUB_EMULATOR_HOST = process.env.PUBSUB_EMULATOR_HOST;

--- a/test/snapshot.ts
+++ b/test/snapshot.ts
@@ -84,12 +84,6 @@ describe('Snapshot', () => {
       assert(promisified);
     });
 
-    it('should localize parent.Promise', () => {
-      const pubsub = new PubSub();
-      snapshot = new Snapshot(pubsub, SNAPSHOT_NAME);
-      assert.strictEqual(snapshot.Promise, pubsub.Promise);
-    });
-
     it('should localize the parent', () => {
       assert.strictEqual(snapshot.parent, SUBSCRIPTION);
     });

--- a/test/subscription.ts
+++ b/test/subscription.ts
@@ -89,7 +89,6 @@ describe('Subscription', () => {
 
   const PUBSUB = ({
     projectId: PROJECT_ID,
-    Promise: {},
     request: util.noop,
     createSubscription: util.noop,
   } as {}) as PubSub;

--- a/test/topic.ts
+++ b/test/topic.ts
@@ -95,7 +95,6 @@ describe('Topic', () => {
 
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   const PUBSUB: any = {
-    Promise: {},
     projectId: PROJECT_ID,
     createTopic: util.noop,
     request: util.noop,
@@ -130,10 +129,6 @@ describe('Topic', () => {
 
     it('should promisify all the things', () => {
       assert(promisified);
-    });
-
-    it('should localize pubsub.Promise', () => {
-      assert.strictEqual(topic.Promise, PUBSUB.Promise);
     });
 
     it('should format the name', () => {


### PR DESCRIPTION
BREAKING CHANGE: This change removes the `PubSub.Promise` property that could be used to override the default Promise implementation in node.js.  In years past, this option made sense as native Promise support on the platform lagged behind.  Today, the promise implementation in node.js is complete and performant.  