### PR TITLE
DO NOT MERGE: fix(deps): use google-gax and protobufjs next

### DIFF
--- a/package.json
+++ b/package.json
@@ -56,11 +56,11 @@
     "async-each": "^1.0.1",
     "extend": "^3.0.2",
     "google-auth-library": "^6.0.0",
-    "google-gax": "^2.1.0",
+    "google-gax": "next",
     "is-stream-ended": "^0.1.4",
     "lodash.snakecase": "^4.1.1",
     "p-defer": "^3.0.0",
-    "protobufjs": "^6.8.1"
+    "protobufjs": "next"
   },
   "devDependencies": {
     "@grpc/proto-loader": "^0.5.2",


### PR DESCRIPTION
Extra testing before releasing `protobufjs` v6.9.0 and `@grpc/grpc-js` v0.8.1.