### PR TITLE
fix(close): ensure in-flight messages are drained (#952)

### DIFF
--- a/src/message-queues.ts
+++ b/src/message-queues.ts
@@ -76,7 +76,9 @@ export class BatchError extends Error implements ServiceError {
  */
 export abstract class MessageQueue {
   numPendingRequests: number;
+  numInFlightRequests: number;
   protected _onFlush?: defer.DeferredPromise<void>;
+  protected _onDrain?: defer.DeferredPromise<void>;
   protected _options!: BatchOptions;
   protected _requests: QueuedMessages;
   protected _subscriber: Subscriber;
@@ -84,6 +86,7 @@ export abstract class MessageQueue {
   protected abstract _sendBatch(batch: QueuedMessages): Promise<void>;
   constructor(sub: Subscriber, options = {} as BatchOptions) {
     this.numPendingRequests = 0;
+    this.numInFlightRequests = 0;
     this._requests = [];
     this._subscriber = sub;
 
@@ -110,6 +113,7 @@ export abstract class MessageQueue {
 
     this._requests.push([ackId, deadline]);
     this.numPendingRequests += 1;
+    this.numInFlightRequests += 1;
 
     if (this._requests.length >= maxMessages!) {
       this.flush();
@@ -141,8 +145,14 @@ export abstract class MessageQueue {
       this._subscriber.emit('error', e);
     }
 
+    this.numInFlightRequests -= batchSize;
     if (deferred) {
       deferred.resolve();
+    }
+
+    if (this.numInFlightRequests <= 0 && this._onDrain) {
+      this._onDrain.resolve();
+      delete this._onDrain;
     }
   }
   /**
@@ -156,6 +166,15 @@ export abstract class MessageQueue {
       this._onFlush = defer();
     }
     return this._onFlush.promise;
+  }
+  /**
+   * Returns a promise that resolves when all in-flight messages have settled.
+   */
+  onDrain(): Promise<void> {
+    if (!this._onDrain) {
+      this._onDrain = defer();
+    }
+    return this._onDrain.promise;
   }
   /**
    * Set the batching options.

--- a/src/subscriber.ts
+++ b/src/subscriber.ts
@@ -466,6 +466,14 @@ export class Subscriber extends EventEmitter {
       this._modAcks.flush();
     }
 
+    if (this._acks.numInFlightRequests) {
+      promises.push(this._acks.onDrain());
+    }
+
+    if (this._modAcks.numInFlightRequests) {
+      promises.push(this._modAcks.onDrain());
+    }
+
     await Promise.all(promises);
   }
 }

--- a/system-test/pubsub.ts
+++ b/system-test/pubsub.ts
@@ -880,7 +880,7 @@ describe('pubsub', () => {
             subscription.on('error', done);
             subscription.on('message', message => {
               // If we get the default message from before() then this fails.
-              assert.equal(message.data.toString(), testText);
+              assert.strictEqual(message.data.toString(), testText);
               message.ack();
               subscription.close(done);
             });

--- a/test/message-queues.ts
+++ b/test/message-queues.ts
@@ -22,6 +22,7 @@ import {Metadata, ServiceError} from '@grpc/grpc-js';
 import * as proxyquire from 'proxyquire';
 import * as sinon from 'sinon';
 import * as uuid from 'uuid';
+import defer = require('p-defer');
 
 import * as messageTypes from '../src/message-queues';
 import {BatchError} from '../src/message-queues';
@@ -75,13 +76,13 @@ describe('MessageQueues', () => {
   // tslint:disable-next-line variable-name
   let ModAckQueue: typeof messageTypes.ModAckQueue;
 
+  type QueuedMessages = Array<[string, number?]>;
+
   before(() => {
     const queues = proxyquire('../src/message-queues.js', {});
 
     AckQueue = queues.AckQueue;
     ModAckQueue = queues.ModAckQueue;
-
-    type QueuedMessages = Array<[string, number?]>;
 
     MessageQueue = class MessageQueue extends queues.MessageQueue {
       batches = [] as QueuedMessages[];
@@ -209,6 +210,35 @@ describe('MessageQueues', () => {
         setImmediate(() => messageQueue.flush());
         return promise;
       });
+
+      it('should resolve onDrain only after all in-flight messages have been flushed', async () => {
+        const log: string[] = [];
+        const sendDone = defer();
+        sandbox.stub(messageQueue, '_sendBatch').callsFake(async () => {
+          log.push('send:start');
+          await sendDone.promise;
+          log.push('send:end');
+        });
+
+        const message = new FakeMessage();
+        const deadline = 10;
+        const onDrainBeforeFlush = messageQueue
+          .onDrain()
+          .then(() => log.push('drain1'));
+        messageQueue.add(message as Message, deadline);
+        messageQueue.flush();
+        assert.deepStrictEqual(log, ['send:start']);
+        sendDone.resolve();
+        await messageQueue.onDrain().then(() => log.push('drain2'));
+        await onDrainBeforeFlush;
+
+        assert.deepStrictEqual(log, [
+          'send:start',
+          'send:end',
+          'drain1',
+          'drain2',
+        ]);
+      });
     });
 
     describe('onFlush', () => {
@@ -221,6 +251,21 @@ describe('MessageQueues', () => {
       it('should re-use existing promises', () => {
         const promise1 = messageQueue.onFlush();
         const promise2 = messageQueue.onFlush();
+
+        assert.strictEqual(promise1, promise2);
+      });
+    });
+
+    describe('onDrain', () => {
+      it('should create a promise', () => {
+        const promise = messageQueue.onDrain();
+
+        assert(promise instanceof Promise);
+      });
+
+      it('should re-use existing promises', () => {
+        const promise1 = messageQueue.onDrain();
+        const promise2 = messageQueue.onDrain();
 
         assert.strictEqual(promise1, promise2);
       });

--- a/test/subscriber.ts
+++ b/test/subscriber.ts
@@ -84,6 +84,7 @@ class FakeLeaseManager extends EventEmitter {
 class FakeQueue {
   options: BatchOptions;
   numPendingRequests = 0;
+  numInFlightRequests = 0;
   maxMilliseconds = 100;
   constructor(sub: s.Subscriber, options: BatchOptions) {
     this.options = options;
@@ -91,6 +92,7 @@ class FakeQueue {
   add(message: s.Message, deadline?: number): void {}
   async flush(): Promise<void> {}
   async onFlush(): Promise<void> {}
+  async onDrain(): Promise<void> {}
 }
 
 class FakeAckQueue extends FakeQueue {
@@ -386,6 +388,7 @@ describe('Subscriber', () => {
 
         sandbox.stub(ackQueue, 'flush').rejects();
         sandbox.stub(ackQueue, 'onFlush').rejects();
+        sandbox.stub(ackQueue, 'onDrain').rejects();
 
         const modAckQueue: FakeModAckQueue = stubs.get('modAckQueue');
 
@@ -393,6 +396,20 @@ describe('Subscriber', () => {
         sandbox.stub(modAckQueue, 'onFlush').rejects();
 
         return subscriber.close();
+      });
+
+      it('should wait for in-flight messages to drain', async () => {
+        const ackQueue: FakeAckQueue = stubs.get('ackQueue');
+        const modAckQueue: FakeModAckQueue = stubs.get('modAckQueue');
+        const ackOnDrain = sandbox.stub(ackQueue, 'onDrain').resolves();
+        const modAckOnDrain = sandbox.stub(modAckQueue, 'onDrain').resolves();
+
+        ackQueue.numInFlightRequests = 1;
+        modAckQueue.numInFlightRequests = 1;
+        await subscriber.close();
+
+        assert.strictEqual(ackOnDrain.callCount, 1);
+        assert.strictEqual(modAckOnDrain.callCount, 1);
       });
     });
   });


### PR DESCRIPTION
Backporting this fix to the legacy-8 branch.
