### PR TITLE
refactor: use grpc from google-gax

### DIFF
--- a/bin/benchwrapper.js
+++ b/bin/benchwrapper.js
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-const grpc = require('grpc');
+const {grpc} = require('google-gax');
 const protoLoader = require('@grpc/proto-loader');
 const {PubSub} = require('../build/src');
 
@@ -67,5 +67,14 @@ server.addService(pubsubBenchWrapper['PubsubBenchWrapper']['service'], {
   Recv: recv,
 });
 console.log(`starting on localhost:${argv.port}`);
-server.bind(`0.0.0.0:${argv.port}`, grpc.ServerCredentials.createInsecure());
-server.start();
+server.bindAsync(
+  `0.0.0.0:${argv.port}`,
+  grpc.ServerCredentials.createInsecure(),
+  err => {
+    if (err) {
+      throw err;
+    } else {
+      server.start();
+    }
+  }
+);

--- a/package.json
+++ b/package.json
@@ -64,7 +64,7 @@
     "protobufjs": "^6.8.1"
   },
   "devDependencies": {
-    "@grpc/proto-loader": "^0.5.2",
+    "@grpc/proto-loader": "^0.5.4",
     "@types/execa": "^0.9.0",
     "@types/extend": "^3.0.0",
     "@types/lodash.snakecase": "^4.1.6",
@@ -79,7 +79,6 @@
     "c8": "^7.0.0",
     "codecov": "^3.0.0",
     "execa": "^4.0.0",
-    "grpc": "^1.24.0",
     "gts": "^2.0.0",
     "jsdoc": "^3.6.2",
     "jsdoc-fresh": "^1.0.1",

--- a/src/index.ts
+++ b/src/index.ts
@@ -148,10 +148,9 @@ export {
 
 if (process.env.DEBUG_GRPC) {
   console.info('gRPC logging set to verbose');
-  // eslint-disable-next-line
-  const {setLogger, setLogVerbosity, logVerbosity} = require('@grpc/grpc-js');
-  setLogger(console);
-  setLogVerbosity(logVerbosity.DEBUG);
+  const grpc = require('google-gax').grpc;
+  grpc.setLogger(console);
+  grpc.setLogVerbosity(grpc.logVerbosity.DEBUG);
 }
 import * as protos from '../protos/protos';
 export {protos};

--- a/src/message-queues.ts
+++ b/src/message-queues.ts
@@ -14,9 +14,7 @@
  * limitations under the License.
  */
 
-import {CallOptions} from 'google-gax';
-// eslint-disable-next-line node/no-extraneous-import
-import {Metadata, ServiceError, status} from '@grpc/grpc-js';
+import {CallOptions, grpc} from 'google-gax';
 import defer = require('p-defer');
 
 import {Message, Subscriber} from './subscriber';
@@ -37,12 +35,12 @@ export interface BatchOptions {
  * @param {string} message The error message.
  * @param {ServiceError} err The grpc service error.
  */
-export class BatchError extends Error implements ServiceError {
+export class BatchError extends Error implements grpc.ServiceError {
   ackIds: string[];
-  code: status;
+  code: grpc.status;
   details: string;
-  metadata: Metadata;
-  constructor(err: ServiceError, ackIds: string[], rpc: string) {
+  metadata: grpc.Metadata;
+  constructor(err: grpc.ServiceError, ackIds: string[], rpc: string) {
     super(
       `Failed to "${rpc}" for ${ackIds.length} message(s). Reason: ${
         process.env.DEBUG_GRPC ? err.stack : err.message

--- a/src/publisher/publish-error.ts
+++ b/src/publisher/publish-error.ts
@@ -13,9 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
-// eslint-disable-next-line node/no-extraneous-import
-import {ServiceError, Metadata, status} from '@grpc/grpc-js';
+import {grpc} from 'google-gax';
 
 /**
  * Exception to be thrown during failed ordered publish.
@@ -23,17 +21,17 @@ import {ServiceError, Metadata, status} from '@grpc/grpc-js';
  * @class
  * @extends Error
  */
-export class PublishError extends Error implements ServiceError {
-  code: status;
+export class PublishError extends Error implements grpc.ServiceError {
+  code: grpc.status;
   details: string;
-  metadata: Metadata;
+  metadata: grpc.Metadata;
   orderingKey: string;
-  error: ServiceError;
-  constructor(key: string, err: ServiceError) {
+  error: grpc.ServiceError;
+  constructor(key: string, err: grpc.ServiceError) {
     super(`Unable to publish for key "${key}". Reason: ${err.message}`);
 
     /**
-     * The gRPC status code.
+     * The gRPC grpc.status code.
      *
      * @name PublishError#code
      * @type {number}
@@ -41,7 +39,7 @@ export class PublishError extends Error implements ServiceError {
     this.code = err.code;
 
     /**
-     * The gRPC status details.
+     * The gRPC grpc.status details.
      *
      * @name PublishError#details
      * @type {string}
@@ -49,9 +47,9 @@ export class PublishError extends Error implements ServiceError {
     this.details = err.details;
 
     /**
-     * The gRPC metadata object.
+     * The gRPC grpc.Metadata object.
      *
-     * @name PublishError#metadata
+     * @name PublishError#grpc.Metadata
      * @type {object}
      */
     this.metadata = err.metadata;

--- a/src/pubsub.ts
+++ b/src/pubsub.ts
@@ -20,10 +20,6 @@ import {promisifyAll} from '@google-cloud/promisify';
 import * as extend from 'extend';
 import {GoogleAuth} from 'google-auth-library';
 import * as gax from 'google-gax';
-// eslint-disable-next-line node/no-extraneous-import
-import * as grpc from '@grpc/grpc-js';
-// eslint-disable-next-line node/no-extraneous-import
-import {ServiceError, ChannelCredentials} from '@grpc/grpc-js';
 
 // eslint-disable-next-line @typescript-eslint/no-var-requires
 const PKG = require('../../package.json');
@@ -64,7 +60,7 @@ export interface ClientConfig extends gax.GrpcClientOptions {
   apiEndpoint?: string;
   servicePath?: string;
   port?: string | number;
-  sslCreds?: ChannelCredentials;
+  sslCreds?: gax.grpc.ChannelCredentials;
 }
 
 export interface PageOptions {
@@ -132,7 +128,7 @@ export interface RequestConfig extends GetClientConfig {
 
 export interface ResourceCallback<Resource, Response> {
   (
-    err: ServiceError | null,
+    err: gax.grpc.ServiceError | null,
     resource?: Resource | null,
     response?: Response | null
   ): void;
@@ -143,12 +139,12 @@ export type RequestCallback<T, R = void> = R extends void
   : PagedCallback<T, R>;
 
 export interface NormalCallback<TResponse> {
-  (err: ServiceError | null, res?: TResponse | null): void;
+  (err: gax.grpc.ServiceError | null, res?: TResponse | null): void;
 }
 
 export interface PagedCallback<Item, Response> {
   (
-    err: ServiceError | null,
+    err: gax.grpc.ServiceError | null,
     results?: Item[] | null,
     nextQuery?: {} | null,
     response?: Response | null
@@ -559,7 +555,7 @@ export class PubSub {
       return;
     }
 
-    const grpcInstance = this.options.grpc || grpc;
+    const grpcInstance = this.options.grpc || gax.grpc;
     const baseUrl = apiEndpoint || process.env.PUBSUB_EMULATOR_HOST;
     const leadingProtocol = new RegExp('^https*://');
     const trailingSlashes = new RegExp('/*$');
@@ -1009,13 +1005,13 @@ export class PubSub {
       };
       const err = new Error(statusObject.details);
       Object.assign(err, statusObject);
-      callback(err as ServiceError);
+      callback(err as gax.grpc.ServiceError);
       return;
     }
 
     this.getClient_(config, (err, client) => {
       if (err) {
-        callback(err as ServiceError);
+        callback(err as gax.grpc.ServiceError);
         return;
       }
       let reqOpts = extend(true, {}, config.reqOpts);

--- a/src/pull-retry.ts
+++ b/src/pull-retry.ts
@@ -13,18 +13,17 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-// eslint-disable-next-line node/no-extraneous-import
-import {StatusObject, status} from '@grpc/grpc-js';
+import {grpc} from 'google-gax';
 
 /*!
- * retryable status codes
+ * retryable grpc.status codes
  */
-export const RETRY_CODES: status[] = [
-  status.DEADLINE_EXCEEDED,
-  status.RESOURCE_EXHAUSTED,
-  status.ABORTED,
-  status.INTERNAL,
-  status.UNAVAILABLE,
+export const RETRY_CODES: grpc.status[] = [
+  grpc.status.DEADLINE_EXCEEDED,
+  grpc.status.RESOURCE_EXHAUSTED,
+  grpc.status.ABORTED,
+  grpc.status.INTERNAL,
+  grpc.status.UNAVAILABLE,
 ];
 
 /**
@@ -51,7 +50,7 @@ export class PullRetry {
     return Math.pow(2, this.failures) * 1000 + Math.floor(Math.random() * 1000);
   }
   /**
-   * Determines if a request status should be retried.
+   * Determines if a request grpc.status should be retried.
    *
    * Deadlines behave kind of unexpectedly on streams, rather than using it as
    * an indicator of when to give up trying to connect, it actually dictates
@@ -60,18 +59,21 @@ export class PullRetry {
    * the server closing the stream or if we timed out waiting for a connection.
    *
    * @private
-   * @param {object} status The request status.
+   * @param {object} grpc.status The request grpc.status.
    * @returns {boolean}
    */
-  retry(err: StatusObject): boolean {
-    if (err.code === status.OK || err.code === status.DEADLINE_EXCEEDED) {
+  retry(err: grpc.StatusObject): boolean {
+    if (
+      err.code === grpc.status.OK ||
+      err.code === grpc.status.DEADLINE_EXCEEDED
+    ) {
       this.failures = 0;
     } else {
       this.failures += 1;
     }
 
     if (
-      err.code === status.UNAVAILABLE &&
+      err.code === grpc.status.UNAVAILABLE &&
       err.details &&
       err.details.match(/Server shutdownNow invoked/)
     ) {

--- a/test/message-queues.ts
+++ b/test/message-queues.ts
@@ -17,9 +17,7 @@
 import * as assert from 'assert';
 import {describe, it, before, beforeEach, afterEach} from 'mocha';
 import {EventEmitter} from 'events';
-import {CallOptions} from 'google-gax';
-// eslint-disable-next-line node/no-extraneous-import
-import {Metadata, ServiceError} from '@grpc/grpc-js';
+import {CallOptions, grpc} from 'google-gax';
 import * as proxyquire from 'proxyquire';
 import * as sinon from 'sinon';
 import * as uuid from 'uuid';
@@ -373,9 +371,9 @@ describe('MessageQueues', () => {
 
       const ackIds = messages.map(message => message.ackId);
 
-      const fakeError = new Error('Err.') as ServiceError;
+      const fakeError = new Error('Err.') as grpc.ServiceError;
       fakeError.code = 2;
-      fakeError.metadata = new Metadata();
+      fakeError.metadata = new grpc.Metadata();
 
       const expectedMessage =
         'Failed to "acknowledge" for 3 message(s). Reason: Err.';
@@ -498,9 +496,9 @@ describe('MessageQueues', () => {
 
       const ackIds = messages.map(message => message.ackId);
 
-      const fakeError = new Error('Err.') as ServiceError;
+      const fakeError = new Error('Err.') as grpc.ServiceError;
       fakeError.code = 2;
-      fakeError.metadata = new Metadata();
+      fakeError.metadata = new grpc.Metadata();
 
       const expectedMessage =
         'Failed to "modifyAckDeadline" for 3 message(s). Reason: Err.';

--- a/test/message-stream.ts
+++ b/test/message-stream.ts
@@ -16,8 +16,7 @@
 
 import * as assert from 'assert';
 import {describe, it, before, beforeEach, afterEach, after} from 'mocha';
-// eslint-disable-next-line node/no-extraneous-import
-import {Metadata, ServiceError} from '@grpc/grpc-js';
+import {grpc} from 'google-gax';
 import * as proxyquire from 'proxyquire';
 import * as sinon from 'sinon';
 import {Duplex, PassThrough} from 'stream';
@@ -88,7 +87,7 @@ class FakeGrpcStream extends Duplex {
     const status = {
       code: 1,
       details: 'Canceled.',
-      metadata: new Metadata(),
+      metadata: new grpc.Metadata(),
     };
 
     process.nextTick(() => {
@@ -429,7 +428,7 @@ describe('MessageStream', () => {
         const fakeError = new Error('err');
         const expectedMessage = 'Failed to connect to channel. Reason: err';
 
-        ms.on('error', (err: ServiceError) => {
+        ms.on('error', (err: grpc.ServiceError) => {
           assert.strictEqual(err.code, 2);
           assert.strictEqual(err.message, expectedMessage);
           assert.strictEqual(ms.destroyed, true);
@@ -447,7 +446,7 @@ describe('MessageStream', () => {
         const ms = new MessageStream(subscriber);
         const fakeError = new Error('Failed to connect before the deadline');
 
-        ms.on('error', (err: ServiceError) => {
+        ms.on('error', (err: grpc.ServiceError) => {
           assert.strictEqual(err.code, 4);
           done();
         });
@@ -533,7 +532,7 @@ describe('MessageStream', () => {
           details: 'Err',
         };
 
-        messageStream.on('error', (err: ServiceError) => {
+        messageStream.on('error', (err: grpc.ServiceError) => {
           assert(err instanceof Error);
           assert.strictEqual(err.code, fakeStatus.code);
           assert.strictEqual(err.message, fakeStatus.details);

--- a/test/publisher/publish-error.ts
+++ b/test/publisher/publish-error.ts
@@ -16,19 +16,18 @@
 
 import * as assert from 'assert';
 import {describe, it, beforeEach} from 'mocha';
-// eslint-disable-next-line node/no-extraneous-import
-import {ServiceError, Metadata} from '@grpc/grpc-js';
+import {grpc} from 'google-gax';
 import {PublishError} from '../../src/publisher/publish-error';
 
 describe('PublishError', () => {
   let error: PublishError;
 
   const orderingKey = 'abcd';
-  const fakeError = new Error('Oh noes') as ServiceError;
+  const fakeError = new Error('Oh noes') as grpc.ServiceError;
 
   fakeError.code = 1;
   fakeError.details = 'Something went wrong!';
-  fakeError.metadata = new Metadata();
+  fakeError.metadata = new grpc.Metadata();
 
   beforeEach(() => {
     error = new PublishError(orderingKey, fakeError);

--- a/test/pull-retry.ts
+++ b/test/pull-retry.ts
@@ -15,8 +15,7 @@
 import * as assert from 'assert';
 import * as sinon from 'sinon';
 import {describe, it, beforeEach, afterEach} from 'mocha';
-// eslint-disable-next-line node/no-extraneous-import
-import {StatusObject, status} from '@grpc/grpc-js';
+import {grpc} from 'google-gax';
 import {PullRetry} from '../src/pull-retry';
 
 describe('PullRetry', () => {
@@ -43,7 +42,7 @@ describe('PullRetry', () => {
 
       sandbox.stub(global.Math, 'random').returns(random);
 
-      retrier.retry({code: status.CANCELLED} as StatusObject);
+      retrier.retry({code: grpc.status.CANCELLED} as grpc.StatusObject);
       assert.strictEqual(retrier.createTimeout(), expected);
     });
   });
@@ -51,47 +50,47 @@ describe('PullRetry', () => {
   describe('retry', () => {
     it('should return true for retryable errors', () => {
       [
-        status.DEADLINE_EXCEEDED,
-        status.RESOURCE_EXHAUSTED,
-        status.ABORTED,
-        status.INTERNAL,
-        status.UNAVAILABLE,
-      ].forEach((code: status) => {
-        const shouldRetry = retrier.retry({code} as StatusObject);
+        grpc.status.DEADLINE_EXCEEDED,
+        grpc.status.RESOURCE_EXHAUSTED,
+        grpc.status.ABORTED,
+        grpc.status.INTERNAL,
+        grpc.status.UNAVAILABLE,
+      ].forEach((code: grpc.status) => {
+        const shouldRetry = retrier.retry({code} as grpc.StatusObject);
         assert.strictEqual(shouldRetry, true);
       });
 
       const serverShutdown = retrier.retry({
-        code: status.UNAVAILABLE,
+        code: grpc.status.UNAVAILABLE,
         details: 'Server shutdownNow invoked',
-      } as StatusObject);
+      } as grpc.StatusObject);
       assert.strictEqual(serverShutdown, true);
     });
 
     it('should return false for non-retryable errors', () => {
       [
-        status.INVALID_ARGUMENT,
-        status.NOT_FOUND,
-        status.PERMISSION_DENIED,
-        status.FAILED_PRECONDITION,
-        status.OUT_OF_RANGE,
-        status.UNIMPLEMENTED,
-      ].forEach((code: status) => {
-        const shouldRetry = retrier.retry({code} as StatusObject);
+        grpc.status.INVALID_ARGUMENT,
+        grpc.status.NOT_FOUND,
+        grpc.status.PERMISSION_DENIED,
+        grpc.status.FAILED_PRECONDITION,
+        grpc.status.OUT_OF_RANGE,
+        grpc.status.UNIMPLEMENTED,
+      ].forEach((code: grpc.status) => {
+        const shouldRetry = retrier.retry({code} as grpc.StatusObject);
         assert.strictEqual(shouldRetry, false);
       });
     });
 
     it('should reset the failure count on OK', () => {
-      retrier.retry({code: status.CANCELLED} as StatusObject);
-      retrier.retry({code: status.OK} as StatusObject);
+      retrier.retry({code: grpc.status.CANCELLED} as grpc.StatusObject);
+      retrier.retry({code: grpc.status.OK} as grpc.StatusObject);
 
       assert.strictEqual(retrier.createTimeout(), 0);
     });
 
     it('should reset the failure count on DEADLINE_EXCEEDED', () => {
-      retrier.retry({code: status.CANCELLED} as StatusObject);
-      retrier.retry({code: status.DEADLINE_EXCEEDED} as StatusObject);
+      retrier.retry({code: grpc.status.CANCELLED} as grpc.StatusObject);
+      retrier.retry({code: grpc.status.DEADLINE_EXCEEDED} as grpc.StatusObject);
 
       assert.strictEqual(retrier.createTimeout(), 0);
     });


### PR DESCRIPTION
Getting rid of any direct dependency on gRPC.

~~Also, `grpc` dev dependency looks completely unused, so removing it :)~~
Upd. It's used by `bin/benchwrapper.js`. Changed that to use gRPC exported from `google-gax` as well.