### PR TITLE
DO NOT MERGE: fix(deps): use google-gax v2.6.2-beta.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -56,7 +56,7 @@
     "arrify": "^2.0.0",
     "extend": "^3.0.2",
     "google-auth-library": "^6.0.0",
-    "google-gax": "^2.1.0",
+    "google-gax": "2.6.2-beta.1",
     "is-stream-ended": "^0.1.4",
     "lodash.snakecase": "^4.1.1",
     "p-defer": "^3.0.0",


### PR DESCRIPTION
Testing `google-gax` `2.6.2-beta.1` with `@grpc/grpc-js` `1.1.1`.
