### PR TITLE
docs: add a link to the changelog file from the main readme

### DIFF
--- a/.readme-partials.yml
+++ b/.readme-partials.yml
@@ -8,6 +8,9 @@ introduction: |-
         [Pub/Sub quickstart](https://cloud.google.com/pubsub/docs/quickstart-client-libraries),
         [publisher](https://cloud.google.com/pubsub/docs/publisher), and [subscriber](https://cloud.google.com/pubsub/docs/subscriber)
         guides.
+
+        A fairly comprehensive list of changes in each version may be found in
+        [the CHANGELOG](https://github.com/googleapis/nodejs-pubsub/blob/master/CHANGELOG.md).
 body: |-
         ## Running gRPC C++ bindings
 

--- a/README.md
+++ b/README.md
@@ -21,6 +21,9 @@ For additional help developing Pub/Sub applications, in Node.js and other langua
 [publisher](https://cloud.google.com/pubsub/docs/publisher), and [subscriber](https://cloud.google.com/pubsub/docs/subscriber)
 guides.
 
+A fairly comprehensive list of changes in each version may be found in
+[the CHANGELOG](https://github.com/googleapis/nodejs-pubsub/blob/master/CHANGELOG.md).
+
 
 * [Google Cloud Pub/Sub Node.js Client API Reference][client-docs]
 * [Google Cloud Pub/Sub Documentation][product-docs]


### PR DESCRIPTION
This adds an explicit link to the most recent version of the CHANGELOG file, to make it easier to see what's changed.

Synthtool should regenerate this file fully on its next run, but I wanted to go ahead and push out a regenerated version of that one file.

Quick fix for https://github.com/googleapis/nodejs-pubsub/issues/1007

