### PR TITLE
feat: update to TypeScript 3.8+ to match gax/protobufjs

### DIFF
--- a/package.json
+++ b/package.json
@@ -93,7 +93,7 @@
     "sinon": "^9.0.0",
     "tmp": "^0.2.0",
     "ts-loader": "^8.0.0",
-    "typescript": "3.6.4",
+    "typescript": "^3.8.3",
     "uuid": "^8.0.0",
     "webpack": "^4.42.0",
     "webpack-cli": "^3.3.11",

--- a/test/message-stream.ts
+++ b/test/message-stream.ts
@@ -69,7 +69,7 @@ class FakePassThrough extends PassThrough {
     this.options = options;
   }
   destroy(err?: Error): void {
-    if (super.destroy) {
+    if (typeof super.destroy === 'function') {
       return super.destroy(err);
     }
     destroy(this, err);
@@ -96,7 +96,7 @@ class FakeGrpcStream extends Duplex {
     });
   }
   destroy(err?: Error): void {
-    if (super.destroy) {
+    if (typeof super.destroy === 'function') {
       return super.destroy(err);
     }
     destroy(this, err);

--- a/test/pubsub.ts
+++ b/test/pubsub.ts
@@ -307,11 +307,12 @@ describe('PubSub', () => {
       name: 'subscription-name',
     };
 
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const subClass = Subscription as any;
+
     beforeEach(() => {
-      ((Subscription as {}) as typeof subby.Subscription).formatMetadata_ = (
-        metadata: subby.SubscriptionMetadata
-      ) => {
-        return Object.assign({}, metadata) as subby.SubscriptionMetadata;
+      subClass.formatMetadata_ = (metadata: {}) => {
+        return Object.assign({}, metadata);
       };
     });
 
@@ -469,11 +470,9 @@ describe('PubSub', () => {
         a: 'a',
       };
 
-      ((Subscription as {}) as typeof subby.Subscription).formatMetadata_ = (
-        metadata: subby.SubscriptionMetadata
-      ) => {
+      subClass.formatMetadata_ = (metadata: {}) => {
         assert.deepStrictEqual(metadata, fakeMetadata);
-        return (formatted as {}) as subby.SubscriptionMetadata;
+        return formatted;
       };
 
       pubsub.request = (config: pubsubTypes.RequestConfig) => {

--- a/test/subscription.ts
+++ b/test/subscription.ts
@@ -919,8 +919,11 @@ describe('Subscription', () => {
       pushEndpoint: 'http://noop.com/push',
     };
 
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const subClass = subby.Subscription as any;
+
     beforeEach(() => {
-      Subscription.formatMetadata_ = (metadata: subby.SubscriptionMetadata) => {
+      subClass.formatMetadata_ = (metadata: {}) => {
         return Object.assign({}, metadata);
       };
     });


### PR DESCRIPTION
Update to TypeScript 3.8+ to match gax/protobufjs (to allow things to compile again)

Fixes https://github.com/googleapis/nodejs-pubsub/issues/1074

Still a bit of discussion going on about whether this should be a `feat` or `feat!`
