### PR TITLE
build: re-enable renovate support for typescript

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -14,6 +14,5 @@
       "extends": "packages:linters",
       "groupName": "linters"
     }
-  ],
-  "ignoreDeps": ["typescript"]
+  ]
 }


### PR DESCRIPTION
This was disabled in https://github.com/googleapis/nodejs-pubsub/commit/e779c70c6b11600a382880c611b82eae6b60c552 due to issues with TypeScript 3.7 breaking Angular. Now we appear to be back on track, this is to help eliminate further problems like the incompatibility surprise (https://github.com/googleapis/nodejs-pubsub/pull/1085).
