### PR TITLE
feat: Enable server side flow control by default with the option to turn it off

### DIFF
--- a/src/message-stream.ts
+++ b/src/message-stream.ts
@@ -226,8 +226,12 @@ export class MessageStream extends PassThrough {
     const request: StreamingPullRequest = {
       subscription: this._subscriber.name,
       streamAckDeadlineSeconds: this._subscriber.ackDeadline,
-      maxOutstandingMessages: this._subscriber.useLegacyFlowControl ? 0 : this._subscriber.maxMessages,
-      maxOutstandingBytes: this._subscriber.useLegacyFlowControl ? 0 : this._subscriber.maxBytes,
+      maxOutstandingMessages: this._subscriber.useLegacyFlowControl
+        ? 0
+        : this._subscriber.maxMessages,
+      maxOutstandingBytes: this._subscriber.useLegacyFlowControl
+        ? 0
+        : this._subscriber.maxBytes,
     };
 
     delete this._fillHandle;

--- a/src/message-stream.ts
+++ b/src/message-stream.ts
@@ -226,8 +226,10 @@ export class MessageStream extends PassThrough {
     const request: StreamingPullRequest = {
       subscription: this._subscriber.name,
       streamAckDeadlineSeconds: this._subscriber.ackDeadline,
-      maxOutstandingMessages: this._subscriber.maxMessages,
-      maxOutstandingBytes: this._subscriber.maxBytes,
+      maxOutstandingMessages: this._subscriber.useLegacyFlowControl
+                                    ? 0 : this._subscriber.maxMessages,
+      maxOutstandingBytes: this._subscriber.useLegacyFlowControl
+                                    ? 0 : this._subscriber.maxBytes,
     };
 
     delete this._fillHandle;

--- a/src/message-stream.ts
+++ b/src/message-stream.ts
@@ -226,10 +226,8 @@ export class MessageStream extends PassThrough {
     const request: StreamingPullRequest = {
       subscription: this._subscriber.name,
       streamAckDeadlineSeconds: this._subscriber.ackDeadline,
-      maxOutstandingMessages: this._subscriber.useLegacyFlowControl
-                                    ? 0 : this._subscriber.maxMessages,
-      maxOutstandingBytes: this._subscriber.useLegacyFlowControl
-                                    ? 0 : this._subscriber.maxBytes,
+      maxOutstandingMessages: this._subscriber.useLegacyFlowControl ? 0 : this._subscriber.maxMessages,
+      maxOutstandingBytes: this._subscriber.useLegacyFlowControl ? 0 : this._subscriber.maxBytes,
     };
 
     delete this._fillHandle;


### PR DESCRIPTION
This change enables sending flow control settings automatically to the server.
If flowControl.maxMessages > 0 or flowControl.maxBytes > 0, flow control will
be enforced at the server side (in addition to the client side).

This behavior is enabled by default and SubscriberOptions.useLegacyFlowControl can be used for users who would
like to opt-out of this feature in case they encounter issues with server side
flow control.
