### PR TITLE
tests: add some diagnostics to this potentially flaky test to get more debug info if it happens again

### DIFF
--- a/system-test/pubsub.ts
+++ b/system-test/pubsub.ts
@@ -327,6 +327,17 @@ describe('pubsub', () => {
             const key = message.orderingKey || '';
             const data = message.data.toString();
             const messages = pending[key];
+
+            if (!messages) {
+              deferred.reject(
+                new Error(
+                  `Unknown key "${key}" for test data: ${JSON.stringify(pending, null, 4)}`
+                )
+              );
+              subscription.close();
+              return;
+            }
+
             const expected = messages[0];
 
             if (key && data !== expected) {

--- a/system-test/pubsub.ts
+++ b/system-test/pubsub.ts
@@ -331,7 +331,11 @@ describe('pubsub', () => {
             if (!messages) {
               deferred.reject(
                 new Error(
-                  `Unknown key "${key}" for test data: ${JSON.stringify(pending, null, 4)}`
+                  `Unknown key "${key}" for test data: ${JSON.stringify(
+                    pending,
+                    null,
+                    4
+                  )}`
                 )
               );
               subscription.close();


### PR DESCRIPTION
"Fixes": https://github.com/googleapis/nodejs-pubsub/issues/1166

This test doesn't fail for me locally. It looks like it's expecting to receive a bunch of ordering key bucketed messages back, and one of the messages has an unexpected ordering key. This should hopefully give us more info next time.
