### PR TITLE
samples: fix sample name for openTelemetryTracing

### DIFF
--- a/samples/openTelemetryTracing.js
+++ b/samples/openTelemetryTracing.js
@@ -28,7 +28,7 @@
 //   title: OpenTelemetry Tracing
 //   description: Demonstrates how to enable OpenTelemetry tracing in
 //     a publisher or subscriber.
-//   usage: node opentelemetryTracing.js <topic-name> <subscription-name>
+//   usage: node openTelemetryTracing.js <topic-name> <subscription-name>
 
 const SUBSCRIBER_TIMEOUT = 10;
 


### PR DESCRIPTION
This was causing spurious synthtool updates.
