### PR TITLE
fix: temporarily pin sinon at 10.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -67,6 +67,8 @@
   },
   "devDependencies": {
     "@grpc/proto-loader": "^0.6.0",
+    "@microsoft/api-documenter": "^7.8.10",
+    "@microsoft/api-extractor": "^7.8.10",
     "@types/execa": "^0.9.0",
     "@types/extend": "^3.0.0",
     "@types/lodash.snakecase": "^4.1.6",
@@ -99,8 +101,6 @@
     "uuid": "^8.0.0",
     "webpack": "^5.0.0",
     "webpack-cli": "^4.0.0",
-    "yargs": "^16.0.0",
-    "@microsoft/api-documenter": "^7.8.10",
-    "@microsoft/api-extractor": "^7.8.10"
+    "yargs": "^16.0.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -92,7 +92,7 @@
     "null-loader": "^4.0.0",
     "protobufjs": "^6.10.1",
     "proxyquire": "^2.0.0",
-    "sinon": "^10.0.0",
+    "sinon": "10.0.0",
     "tmp": "^0.2.0",
     "ts-loader": "^8.0.0",
     "typescript": "^3.8.3",


### PR DESCRIPTION
This is to fix some TypeScript compilation errors that are holding up a bunch of PRs in this repo. This will be reverted once upstream is fixed.

https://github.com/sinonjs/sinon/issues/2352
