### PR TITLE
feat: update publisher options all the way through the topic object tree

### DIFF
--- a/src/publisher/index.ts
+++ b/src/publisher/index.ts
@@ -336,5 +336,5 @@ export class Publisher {
 
 promisifyAll(Publisher, {
   singular: true,
-  exclude: ['publish', 'setOptions', 'constructSpan'],
+  exclude: ['publish', 'setOptions', 'constructSpan', 'getOptionDefaults'],
 });

--- a/src/publisher/message-batch.ts
+++ b/src/publisher/message-batch.ts
@@ -51,6 +51,16 @@ export class MessageBatch {
     this.created = Date.now();
     this.bytes = 0;
   }
+
+  /**
+   * Updates our options from new values.
+   *
+   * @param {BatchPublishOptions} options The new options.
+   */
+  setOptions(options: BatchPublishOptions) {
+    this.options = options;
+  }
+
   /**
    * Adds a message to the current batch.
    *

--- a/src/publisher/message-queues.ts
+++ b/src/publisher/message-queues.ts
@@ -42,6 +42,20 @@ export abstract class MessageQueue extends EventEmitter {
     this.publisher = publisher;
     this.batchOptions = publisher.settings.batching!;
   }
+
+  /**
+   * Forces the queue to update its options from the publisher.
+   * The specific queue will need to do a bit more to pass the new
+   * values down into any MessageBatch.
+   *
+   * This is only for use by {@link Publisher}.
+   *
+   * @private
+   */
+  updateOptions() {
+    this.batchOptions = this.publisher.settings.batching!;
+  }
+
   /**
    * Adds a message to the queue.
    *
@@ -114,6 +128,13 @@ export class Queue extends MessageQueue {
     super(publisher);
     this.batch = new MessageBatch(this.batchOptions);
   }
+
+  // This needs to update our existing message batch.
+  updateOptions() {
+    super.updateOptions();
+    this.batch.setOptions(this.batchOptions);
+  }
+
   /**
    * Adds a message to the queue.
    *
@@ -173,6 +194,13 @@ export class OrderedQueue extends MessageQueue {
     this.inFlight = false;
     this.key = key;
   }
+
+  // This needs to update our existing message batches.
+  updateOptions() {
+    super.updateOptions();
+    this.batches.forEach(b => b.setOptions(this.batchOptions));
+  }
+
   /**
    * Reference to the batch we're currently filling.
    * @returns {MessageBatch}

--- a/src/topic.ts
+++ b/src/topic.ts
@@ -1042,6 +1042,7 @@ promisifyAll(Topic, {
     'publishJSON',
     'publishMessage',
     'setPublishOptions',
+    'getPublishOptionDefaults',
     'subscription',
   ],
 });

--- a/src/topic.ts
+++ b/src/topic.ts
@@ -921,6 +921,26 @@ export class Topic {
   }
 
   /**
+   * Get the default publisher options. These may be modified and passed
+   * back into {@link Topic#setPublishOptions}.
+   *
+   * @example
+   * const {PubSub} = require('@google-cloud/pubsub');
+   * const pubsub = new PubSub();
+   *
+   * const topic = pubsub.topic('my-topic');
+   *
+   * const defaults = topic.getPublishOptionDefaults();
+   * defaults.batching.maxMilliseconds = 10;
+   * topic.setPublishOptions(defaults);
+   */
+  getPublishOptionDefaults(): PublishOptions {
+    // Generally I'd leave this as a static, but it'll be easier for users to
+    // get at when they're using the veneer objects.
+    return this.publisher.getOptionDefaults();
+  }
+
+  /**
    * Create a Subscription object. This command by itself will not run any API
    * requests. You will receive a {module:pubsub/subscription} object,
    * which will allow you to interact with a subscription.

--- a/test/publisher/index.ts
+++ b/test/publisher/index.ts
@@ -30,7 +30,6 @@ import {defaultOptions} from '../../src/default-options';
 import {exporter} from '../tracing';
 import {SpanKind} from '@opentelemetry/api';
 import {MessagingAttribute} from '@opentelemetry/semantic-conventions';
-import {google} from '../../protos/protos';
 
 let promisified = false;
 const fakePromisify = Object.assign({}, pfy, {
@@ -38,12 +37,18 @@ const fakePromisify = Object.assign({}, pfy, {
     if (ctor.name !== 'Publisher') {
       return;
     }
+
+    // We _also_ need to call it, because unit tests will catch things
+    // that shouldn't be promisified.
+    pfy.promisifyAll(ctor, options);
+
     promisified = true;
     assert.ok(options.singular);
     assert.deepStrictEqual(options.exclude, [
       'publish',
       'setOptions',
       'constructSpan',
+      'getOptionDefaults',
     ]);
   },
 });

--- a/test/publisher/message-batch.ts
+++ b/test/publisher/message-batch.ts
@@ -174,4 +174,12 @@ describe('MessageBatch', () => {
       assert.strictEqual(isFull, false);
     });
   });
+
+  describe('setOptions', () => {
+    it('updates the options', () => {
+      const newOptions = {};
+      batch.setOptions(newOptions);
+      assert.strictEqual(newOptions, batch.options);
+    });
+  });
 });

--- a/test/publisher/message-queues.ts
+++ b/test/publisher/message-queues.ts
@@ -67,6 +67,9 @@ class FakeMessageBatch {
   isFull(): boolean {
     return false;
   }
+  setOptions(options: b.BatchPublishOptions) {
+    this.options = options;
+  }
 }
 
 class FakePublishError {
@@ -213,6 +216,15 @@ describe('Message Queues', () => {
         assert.ok(queue.batch instanceof FakeMessageBatch);
         assert.strictEqual(queue.batch.options, queue.batchOptions);
       });
+
+      it('should propagate batch options to the message batch when updated', () => {
+        const newConfig = {
+          batching: {},
+        };
+        publisher.settings = newConfig;
+        queue.updateOptions();
+        assert.strictEqual(queue.batch.options, newConfig.batching);
+      });
     });
 
     describe('add', () => {
@@ -338,6 +350,21 @@ describe('Message Queues', () => {
 
       it('should localize the ordering key', () => {
         assert.strictEqual(queue.key, key);
+      });
+
+      it('should propagate batch options to all message batches when updated', () => {
+        const firstBatch = queue.createBatch();
+        const secondBatch = queue.createBatch();
+        queue.batches.push(firstBatch, secondBatch);
+
+        const newConfig = {
+          batching: {},
+        };
+        publisher.settings = newConfig;
+        queue.updateOptions();
+
+        assert.strictEqual(firstBatch.options, newConfig.batching);
+        assert.strictEqual(secondBatch.options, newConfig.batching);
       });
     });
 

--- a/test/pubsub.ts
+++ b/test/pubsub.ts
@@ -61,6 +61,11 @@ const fakePromisify = Object.assign({}, promisify, {
     }
 
     promisified = true;
+
+    // We _also_ need to call it, because unit tests will catch things
+    // that shouldn't be promisified.
+    promisify.promisifyAll(Class, options);
+
     assert.deepStrictEqual(options.exclude, [
       'request',
       'snapshot',
@@ -316,17 +321,15 @@ describe('PubSub', () => {
       };
     });
 
-    it('should throw if no Topic is provided', () => {
-      assert.throws(() => {
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any
-        (pubsub as any).createSubscription();
+    it('should throw if no Topic is provided', async () => {
+      await assert.rejects(async () => {
+        await pubsub.createSubscription(undefined!, undefined!);
       }, /A Topic is required for a new subscription\./);
     });
 
-    it('should throw if no subscription name is provided', () => {
-      assert.throws(() => {
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any
-        (pubsub as any).createSubscription(TOPIC_NAME);
+    it('should throw if no subscription name is provided', async () => {
+      await assert.rejects(async () => {
+        await pubsub.createSubscription(TOPIC_NAME, undefined!);
       }, /A subscription name is required./);
     });
 
@@ -637,9 +640,9 @@ describe('PubSub', () => {
     };
     const apiResponse = 'responseToCheck';
 
-    it('should throw if no subscription name is provided', () => {
-      assert.throws(() => {
-        pubsub.detachSubscription(undefined!);
+    it('should throw if no subscription name is provided', async () => {
+      await assert.rejects(async () => {
+        await pubsub.detachSubscription(undefined!);
       }, /A subscription name is required./);
     });
 
@@ -666,7 +669,7 @@ describe('PubSub', () => {
     });
 
     it('should detach a Subscription from a string', async () => {
-      sandbox.stub(pubsub, 'request').returns();
+      sandbox.stub(pubsub, 'request').callsArg(1);
       sandbox.stub(pubsub, 'subscription').callsFake(subName => {
         assert.strictEqual(subName, SUB_NAME);
         return SUBSCRIPTION as subby.Subscription;

--- a/test/topic.ts
+++ b/test/topic.ts
@@ -67,6 +67,9 @@ class FakePublisher {
   setOptions(options: object) {
     this.options_ = options;
   }
+  getOptionDefaults() {
+    return this.options_;
+  }
 }
 
 let extended = false;
@@ -704,6 +707,12 @@ describe('Topic', () => {
       topic.setPublishOptions(fakeOptions);
 
       assert.strictEqual(stub.callCount, 1);
+    });
+
+    it('should call through to Publisher#getOptionDefaults', () => {
+      topic.publisher.options_ = {};
+      const defaults = topic.getPublishOptionDefaults();
+      assert.strictEqual(defaults, topic.publisher.options_);
     });
   });
 

--- a/test/topic.ts
+++ b/test/topic.ts
@@ -37,11 +37,17 @@ const fakePromisify = Object.assign({}, pfy, {
       return;
     }
     promisified = true;
+
+    // We _also_ need to call it, because unit tests will catch things
+    // that shouldn't be promisified.
+    pfy.promisifyAll(klass, options);
+
     assert.deepStrictEqual(options.exclude, [
       'publish',
       'publishJSON',
       'publishMessage',
       'setPublishOptions',
+      'getPublishOptionDefaults',
       'subscription',
     ]);
   },


### PR DESCRIPTION
This also adds a defaults getter (`getPublishOptionDefaults()`) for publishing options.

Fixes #1103 🦕🦖🐢
