### PR TITLE
fix: update default RPC retry timeouts to match other languages

### DIFF
--- a/src/v1/publisher_client_config.json
+++ b/src/v1/publisher_client_config.json
@@ -30,8 +30,8 @@
           "initial_retry_delay_millis": 100,
           "retry_delay_multiplier": 1.3,
           "max_retry_delay_millis": 60000,
-          "initial_rpc_timeout_millis": 60000,
-          "rpc_timeout_multiplier": 1,
+          "initial_rpc_timeout_millis": 5000,
+          "rpc_timeout_multiplier": 1.3,
           "max_rpc_timeout_millis": 60000,
           "total_timeout_millis": 600000
         }


### PR DESCRIPTION
Fixes: https://github.com/googleapis/nodejs-pubsub/issues/1398
