### PR TITLE
fix: deprecate maxExtension in favour of maxExtensionMinutes

### DIFF
--- a/src/lease-manager.ts
+++ b/src/lease-manager.ts
@@ -182,10 +182,22 @@ export class LeaseManager extends EventEmitter {
    * Sets options for the LeaseManager.
    *
    * @param {FlowControlOptions} [options] The options.
+   *
+   * @throws {RangeError} If both maxExtension and maxExtensionMinutes are set.
+   *
    * @private
    */
   setOptions(options: FlowControlOptions): void {
-    // Convert the old deprecated maxExtension to avoid breaking clients.
+    // Convert the old deprecated maxExtension to avoid breaking clients,
+    // but allow only one.
+    if (
+      options.maxExtension !== undefined &&
+      options.maxExtensionMinutes !== undefined
+    ) {
+      throw new RangeError(
+        'Only one of "maxExtension" or "maxExtensionMinutes" may be set for subscriber lease management options'
+      );
+    }
     if (
       options.maxExtension !== undefined &&
       options.maxExtensionMinutes === undefined

--- a/test/lease-manager.ts
+++ b/test/lease-manager.ts
@@ -233,6 +233,15 @@ describe('LeaseManager', () => {
         assert.strictEqual(options.maxExtension, undefined);
       });
 
+      it('should not allow both maxExtension and maxExtensionMinutes', () => {
+        assert.throws(() => {
+          leaseManager.setOptions({
+            maxExtension: 10,
+            maxExtensionMinutes: 10,
+          });
+        });
+      });
+
       it('should remove any messages that pass the maxExtensionMinutes value', () => {
         const maxExtensionSeconds = (expectedTimeout - 100) / 1000;
         const badMessages = [new FakeMessage(), new FakeMessage()];

--- a/test/lease-manager.ts
+++ b/test/lease-manager.ts
@@ -224,11 +224,22 @@ describe('LeaseManager', () => {
         });
       });
 
-      it('should remove any messages that pass the maxExtension value', () => {
-        const maxExtension = (expectedTimeout - 100) / 1000;
+      it('should properly convert any legacy maxExtension values', () => {
+        const maxExtension = 60 * 1000;
+        leaseManager.setOptions({maxExtension});
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        const options = (leaseManager as any)._options;
+        assert.strictEqual(options.maxExtensionMinutes, maxExtension / 60);
+        assert.strictEqual(options.maxExtension, undefined);
+      });
+
+      it('should remove any messages that pass the maxExtensionMinutes value', () => {
+        const maxExtensionSeconds = (expectedTimeout - 100) / 1000;
         const badMessages = [new FakeMessage(), new FakeMessage()];
 
-        leaseManager.setOptions({maxExtension});
+        leaseManager.setOptions({
+          maxExtensionMinutes: maxExtensionSeconds / 60,
+        });
         badMessages.forEach(message =>
           leaseManager.add(message as {} as Message)
         );


### PR DESCRIPTION
Background: maxExtension was incorrectly interpreted as seconds in the LeaseManager. This means that if users were relying on client side lease extension in subscribers, they would not actually extend leases for 60 minutes, but only 60 seconds. Also if the user passed in values, they'd be interpreted incorrectly. This PR deprecates the old field in favour of a new one that's explicitly named like the defaults, but also converts the old value if needed.

Fixes: https://github.com/googleapis/nodejs-pubsub/issues/1208