### PR TITLE
fix(cloud-rad): move comments for TSDoc

### DIFF
--- a/src/iam.ts
+++ b/src/iam.ts
@@ -105,6 +105,9 @@ export class IAM {
     this.id = id;
   }
 
+  getPolicy(gaxOpts?: CallOptions): Promise<GetPolicyResponse>;
+  getPolicy(callback: GetPolicyCallback): void;
+  getPolicy(gaxOpts: CallOptions, callback: GetPolicyCallback): void;
   /**
    * @typedef {array} GetPolicyResponse
    * @property {object} 0 The policy.
@@ -146,9 +149,6 @@ export class IAM {
    * });
    * ```
    */
-  getPolicy(gaxOpts?: CallOptions): Promise<GetPolicyResponse>;
-  getPolicy(callback: GetPolicyCallback): void;
-  getPolicy(gaxOpts: CallOptions, callback: GetPolicyCallback): void;
   getPolicy(
     optsOrCallback?: CallOptions | GetPolicyCallback,
     callback?: GetPolicyCallback
@@ -171,6 +171,13 @@ export class IAM {
     );
   }
 
+  setPolicy(policy: Policy, gaxOpts?: CallOptions): Promise<SetPolicyResponse>;
+  setPolicy(
+    policy: Policy,
+    gaxOpts: CallOptions,
+    callback: SetPolicyCallback
+  ): void;
+  setPolicy(policy: Policy, callback: SetPolicyCallback): void;
   /**
    * @typedef {array} SetPolicyResponse
    * @property {object} 0 The policy.
@@ -230,13 +237,6 @@ export class IAM {
    * });
    * ```
    */
-  setPolicy(policy: Policy, gaxOpts?: CallOptions): Promise<SetPolicyResponse>;
-  setPolicy(
-    policy: Policy,
-    gaxOpts: CallOptions,
-    callback: SetPolicyCallback
-  ): void;
-  setPolicy(policy: Policy, callback: SetPolicyCallback): void;
   setPolicy(
     policy: Policy,
     optsOrCallback?: CallOptions | SetPolicyCallback,
@@ -265,6 +265,19 @@ export class IAM {
     );
   }
 
+  testPermissions(
+    permissions: string | string[],
+    gaxOpts?: CallOptions
+  ): Promise<TestIamPermissionsResponse>;
+  testPermissions(
+    permissions: string | string[],
+    gaxOpts: CallOptions,
+    callback: TestIamPermissionsCallback
+  ): void;
+  testPermissions(
+    permissions: string | string[],
+    callback: TestIamPermissionsCallback
+  ): void;
   /**
    * @callback TestIamPermissionsCallback
    * @param {?Error} err Request error, if any.
@@ -345,19 +358,6 @@ export class IAM {
    */
   testPermissions(
     permissions: string | string[],
-    gaxOpts?: CallOptions
-  ): Promise<TestIamPermissionsResponse>;
-  testPermissions(
-    permissions: string | string[],
-    gaxOpts: CallOptions,
-    callback: TestIamPermissionsCallback
-  ): void;
-  testPermissions(
-    permissions: string | string[],
-    callback: TestIamPermissionsCallback
-  ): void;
-  testPermissions(
-    permissions: string | string[],
     optsOrCallback?: CallOptions | TestIamPermissionsCallback,
     callback?: TestIamPermissionsCallback
   ): Promise<TestIamPermissionsResponse> | void {
@@ -405,3 +405,8 @@ export class IAM {
  * that a callback is omitted. Future methods will not allow for a callback.
  * (Use .then() on the returned Promise instead.)
  */
+promisifySome(IAM, IAM.prototype, [
+  'getPolicy',
+  'setPolicy',
+  'testPermissions',
+]);

--- a/src/iam.ts
+++ b/src/iam.ts
@@ -105,9 +105,6 @@ export class IAM {
     this.id = id;
   }
 
-  getPolicy(gaxOpts?: CallOptions): Promise<GetPolicyResponse>;
-  getPolicy(callback: GetPolicyCallback): void;
-  getPolicy(gaxOpts: CallOptions, callback: GetPolicyCallback): void;
   /**
    * @typedef {array} GetPolicyResponse
    * @property {object} 0 The policy.
@@ -149,6 +146,9 @@ export class IAM {
    * });
    * ```
    */
+  getPolicy(gaxOpts?: CallOptions): Promise<GetPolicyResponse>;
+  getPolicy(callback: GetPolicyCallback): void;
+  getPolicy(gaxOpts: CallOptions, callback: GetPolicyCallback): void;
   getPolicy(
     optsOrCallback?: CallOptions | GetPolicyCallback,
     callback?: GetPolicyCallback
@@ -171,13 +171,6 @@ export class IAM {
     );
   }
 
-  setPolicy(policy: Policy, gaxOpts?: CallOptions): Promise<SetPolicyResponse>;
-  setPolicy(
-    policy: Policy,
-    gaxOpts: CallOptions,
-    callback: SetPolicyCallback
-  ): void;
-  setPolicy(policy: Policy, callback: SetPolicyCallback): void;
   /**
    * @typedef {array} SetPolicyResponse
    * @property {object} 0 The policy.
@@ -237,6 +230,13 @@ export class IAM {
    * });
    * ```
    */
+  setPolicy(policy: Policy, gaxOpts?: CallOptions): Promise<SetPolicyResponse>;
+  setPolicy(
+    policy: Policy,
+    gaxOpts: CallOptions,
+    callback: SetPolicyCallback
+  ): void;
+  setPolicy(policy: Policy, callback: SetPolicyCallback): void;
   setPolicy(
     policy: Policy,
     optsOrCallback?: CallOptions | SetPolicyCallback,
@@ -265,19 +265,6 @@ export class IAM {
     );
   }
 
-  testPermissions(
-    permissions: string | string[],
-    gaxOpts?: CallOptions
-  ): Promise<TestIamPermissionsResponse>;
-  testPermissions(
-    permissions: string | string[],
-    gaxOpts: CallOptions,
-    callback: TestIamPermissionsCallback
-  ): void;
-  testPermissions(
-    permissions: string | string[],
-    callback: TestIamPermissionsCallback
-  ): void;
   /**
    * @callback TestIamPermissionsCallback
    * @param {?Error} err Request error, if any.
@@ -356,6 +343,19 @@ export class IAM {
    * });
    * ```
    */
+  testPermissions(
+    permissions: string | string[],
+    gaxOpts?: CallOptions
+  ): Promise<TestIamPermissionsResponse>;
+  testPermissions(
+    permissions: string | string[],
+    gaxOpts: CallOptions,
+    callback: TestIamPermissionsCallback
+  ): void;
+  testPermissions(
+    permissions: string | string[],
+    callback: TestIamPermissionsCallback
+  ): void;
   testPermissions(
     permissions: string | string[],
     optsOrCallback?: CallOptions | TestIamPermissionsCallback,

--- a/src/iam.ts
+++ b/src/iam.ts
@@ -105,9 +105,6 @@ export class IAM {
     this.id = id;
   }
 
-  getPolicy(gaxOpts?: CallOptions): Promise<GetPolicyResponse>;
-  getPolicy(callback: GetPolicyCallback): void;
-  getPolicy(gaxOpts: CallOptions, callback: GetPolicyCallback): void;
   /**
    * @typedef {array} GetPolicyResponse
    * @property {object} 0 The policy.
@@ -149,6 +146,9 @@ export class IAM {
    * });
    * ```
    */
+  getPolicy(gaxOpts?: CallOptions): Promise<GetPolicyResponse>;
+  getPolicy(callback: GetPolicyCallback): void;
+  getPolicy(gaxOpts: CallOptions, callback: GetPolicyCallback): void;
   getPolicy(
     optsOrCallback?: CallOptions | GetPolicyCallback,
     callback?: GetPolicyCallback
@@ -171,13 +171,6 @@ export class IAM {
     );
   }
 
-  setPolicy(policy: Policy, gaxOpts?: CallOptions): Promise<SetPolicyResponse>;
-  setPolicy(
-    policy: Policy,
-    gaxOpts: CallOptions,
-    callback: SetPolicyCallback
-  ): void;
-  setPolicy(policy: Policy, callback: SetPolicyCallback): void;
   /**
    * @typedef {array} SetPolicyResponse
    * @property {object} 0 The policy.
@@ -237,6 +230,13 @@ export class IAM {
    * });
    * ```
    */
+  setPolicy(policy: Policy, gaxOpts?: CallOptions): Promise<SetPolicyResponse>;
+  setPolicy(
+    policy: Policy,
+    gaxOpts: CallOptions,
+    callback: SetPolicyCallback
+  ): void;
+  setPolicy(policy: Policy, callback: SetPolicyCallback): void;
   setPolicy(
     policy: Policy,
     optsOrCallback?: CallOptions | SetPolicyCallback,
@@ -265,19 +265,6 @@ export class IAM {
     );
   }
 
-  testPermissions(
-    permissions: string | string[],
-    gaxOpts?: CallOptions
-  ): Promise<TestIamPermissionsResponse>;
-  testPermissions(
-    permissions: string | string[],
-    gaxOpts: CallOptions,
-    callback: TestIamPermissionsCallback
-  ): void;
-  testPermissions(
-    permissions: string | string[],
-    callback: TestIamPermissionsCallback
-  ): void;
   /**
    * @callback TestIamPermissionsCallback
    * @param {?Error} err Request error, if any.
@@ -358,6 +345,19 @@ export class IAM {
    */
   testPermissions(
     permissions: string | string[],
+    gaxOpts?: CallOptions
+  ): Promise<TestIamPermissionsResponse>;
+  testPermissions(
+    permissions: string | string[],
+    gaxOpts: CallOptions,
+    callback: TestIamPermissionsCallback
+  ): void;
+  testPermissions(
+    permissions: string | string[],
+    callback: TestIamPermissionsCallback
+  ): void;
+  testPermissions(
+    permissions: string | string[],
     optsOrCallback?: CallOptions | TestIamPermissionsCallback,
     callback?: TestIamPermissionsCallback
   ): Promise<TestIamPermissionsResponse> | void {
@@ -405,8 +405,3 @@ export class IAM {
  * that a callback is omitted. Future methods will not allow for a callback.
  * (Use .then() on the returned Promise instead.)
  */
-promisifySome(IAM, IAM.prototype, [
-  'getPolicy',
-  'setPolicy',
-  'testPermissions',
-]);

--- a/src/publisher/index.ts
+++ b/src/publisher/index.ts
@@ -95,6 +95,8 @@ export class Publisher {
     this.orderedQueues = new Map();
   }
 
+  flush(): Promise<void>;
+  flush(callback: EmptyCallback): void;
   /**
    * Immediately sends all remaining queued data. This is mostly useful
    * if you are planning to call close() on the PubSub object that holds
@@ -105,8 +107,6 @@ export class Publisher {
    * @param {EmptyCallback} [callback] Callback function.
    * @returns {Promise<EmptyResponse>}
    */
-  flush(): Promise<void>;
-  flush(callback: EmptyCallback): void;
   flush(callback?: EmptyCallback): Promise<void> | void {
     const definedCallback = callback ? callback : () => {};
 
@@ -122,6 +122,13 @@ export class Publisher {
       })
       .catch(definedCallback);
   }
+  publish(data: Buffer, attributes?: Attributes): Promise<string>;
+  publish(data: Buffer, callback: PublishCallback): void;
+  publish(
+    data: Buffer,
+    attributes: Attributes,
+    callback: PublishCallback
+  ): void;
   /**
    * Publish the provided message.
    *
@@ -136,13 +143,6 @@ export class Publisher {
    * @param {PublishCallback} [callback] Callback function.
    * @returns {Promise<PublishResponse>}
    */
-  publish(data: Buffer, attributes?: Attributes): Promise<string>;
-  publish(data: Buffer, callback: PublishCallback): void;
-  publish(
-    data: Buffer,
-    attributes: Attributes,
-    callback: PublishCallback
-  ): void;
   publish(
     data: Buffer,
     attrsOrCb?: Attributes | PublishCallback,
@@ -153,6 +153,8 @@ export class Publisher {
     return this.publishMessage({data, attributes}, callback!);
   }
 
+  publishMessage(message: PubsubMessage): Promise<string>;
+  publishMessage(message: PubsubMessage, callback: PublishCallback): void;
   /**
    * Publish the provided message.
    *
@@ -164,8 +166,6 @@ export class Publisher {
    * @param {PubsubMessage} [message] Options for this message.
    * @param {PublishCallback} [callback] Callback function.
    */
-  publishMessage(message: PubsubMessage): Promise<string>;
-  publishMessage(message: PubsubMessage, callback: PublishCallback): void;
   publishMessage(
     message: PubsubMessage,
     callback?: PublishCallback

--- a/src/publisher/index.ts
+++ b/src/publisher/index.ts
@@ -95,8 +95,6 @@ export class Publisher {
     this.orderedQueues = new Map();
   }
 
-  flush(): Promise<void>;
-  flush(callback: EmptyCallback): void;
   /**
    * Immediately sends all remaining queued data. This is mostly useful
    * if you are planning to call close() on the PubSub object that holds
@@ -107,6 +105,8 @@ export class Publisher {
    * @param {EmptyCallback} [callback] Callback function.
    * @returns {Promise<EmptyResponse>}
    */
+  flush(): Promise<void>;
+  flush(callback: EmptyCallback): void;
   flush(callback?: EmptyCallback): Promise<void> | void {
     const definedCallback = callback ? callback : () => {};
 
@@ -122,13 +122,6 @@ export class Publisher {
       })
       .catch(definedCallback);
   }
-  publish(data: Buffer, attributes?: Attributes): Promise<string>;
-  publish(data: Buffer, callback: PublishCallback): void;
-  publish(
-    data: Buffer,
-    attributes: Attributes,
-    callback: PublishCallback
-  ): void;
   /**
    * Publish the provided message.
    *
@@ -143,6 +136,13 @@ export class Publisher {
    * @param {PublishCallback} [callback] Callback function.
    * @returns {Promise<PublishResponse>}
    */
+  publish(data: Buffer, attributes?: Attributes): Promise<string>;
+  publish(data: Buffer, callback: PublishCallback): void;
+  publish(
+    data: Buffer,
+    attributes: Attributes,
+    callback: PublishCallback
+  ): void;
   publish(
     data: Buffer,
     attrsOrCb?: Attributes | PublishCallback,
@@ -153,8 +153,6 @@ export class Publisher {
     return this.publishMessage({data, attributes}, callback!);
   }
 
-  publishMessage(message: PubsubMessage): Promise<string>;
-  publishMessage(message: PubsubMessage, callback: PublishCallback): void;
   /**
    * Publish the provided message.
    *
@@ -166,6 +164,8 @@ export class Publisher {
    * @param {PubsubMessage} [message] Options for this message.
    * @param {PublishCallback} [callback] Callback function.
    */
+  publishMessage(message: PubsubMessage): Promise<string>;
+  publishMessage(message: PubsubMessage, callback: PublishCallback): void;
   publishMessage(
     message: PubsubMessage,
     callback?: PublishCallback

--- a/src/pubsub.ts
+++ b/src/pubsub.ts
@@ -313,8 +313,6 @@ export class PubSub {
     return this.projectId.indexOf(PROJECT_ID_PLACEHOLDER) < 0;
   }
 
-  close(): Promise<void>;
-  close(callback: EmptyCallback): void;
   /**
    * Closes out this object, releasing any server connections. Note that once
    * you close a PubSub object, it may not be used again. Any pending operations
@@ -326,6 +324,8 @@ export class PubSub {
    * @callback EmptyCallback
    * @returns {Promise<void>}
    */
+  close(): Promise<void>;
+  close(callback: EmptyCallback): void;
   close(callback?: EmptyCallback): Promise<void> | void {
     const definedCallback = callback || (() => {});
     if (this.isOpen) {
@@ -395,22 +395,6 @@ export class PubSub {
     return new Schema(this, schemaName);
   }
 
-  createSubscription(
-    topic: Topic | string,
-    name: string,
-    options?: CreateSubscriptionOptions
-  ): Promise<CreateSubscriptionResponse>;
-  createSubscription(
-    topic: Topic | string,
-    name: string,
-    callback: CreateSubscriptionCallback
-  ): void;
-  createSubscription(
-    topic: Topic | string,
-    name: string,
-    options: CreateSubscriptionOptions,
-    callback: CreateSubscriptionCallback
-  ): void;
   /**
    * @typedef {array} CreateSubscriptionResponse
    * @property {Subscription} 0 The new {@link Subscription}.
@@ -498,6 +482,22 @@ export class PubSub {
   createSubscription(
     topic: Topic | string,
     name: string,
+    options?: CreateSubscriptionOptions
+  ): Promise<CreateSubscriptionResponse>;
+  createSubscription(
+    topic: Topic | string,
+    name: string,
+    callback: CreateSubscriptionCallback
+  ): void;
+  createSubscription(
+    topic: Topic | string,
+    name: string,
+    options: CreateSubscriptionOptions,
+    callback: CreateSubscriptionCallback
+  ): void;
+  createSubscription(
+    topic: Topic | string,
+    name: string,
     optionsOrCallback?: CreateSubscriptionOptions | CreateSubscriptionCallback,
     callback?: CreateSubscriptionCallback
   ): Promise<CreateSubscriptionResponse> | void {
@@ -556,19 +556,6 @@ export class PubSub {
     );
   }
 
-  createTopic(
-    name: string | TopicMetadata,
-    gaxOpts?: CallOptions
-  ): Promise<CreateTopicResponse>;
-  createTopic(
-    name: string | TopicMetadata,
-    callback: CreateTopicCallback
-  ): void;
-  createTopic(
-    name: string | TopicMetadata,
-    gaxOpts: CallOptions,
-    callback: CreateTopicCallback
-  ): void;
   /**
    * @typedef {array} CreateTopicResponse
    * @property {Topic} 0 The new {@link Topic}.
@@ -613,6 +600,19 @@ export class PubSub {
    */
   createTopic(
     name: string | TopicMetadata,
+    gaxOpts?: CallOptions
+  ): Promise<CreateTopicResponse>;
+  createTopic(
+    name: string | TopicMetadata,
+    callback: CreateTopicCallback
+  ): void;
+  createTopic(
+    name: string | TopicMetadata,
+    gaxOpts: CallOptions,
+    callback: CreateTopicCallback
+  ): void;
+  createTopic(
+    name: string | TopicMetadata,
     optsOrCallback?: CallOptions | CreateTopicCallback,
     callback?: CreateTopicCallback
   ): Promise<CreateTopicResponse> | void {
@@ -650,16 +650,6 @@ export class PubSub {
     );
   }
 
-  detachSubscription(
-    name: string,
-    gaxOpts?: CallOptions
-  ): Promise<DetachSubscriptionResponse>;
-  detachSubscription(name: string, callback: DetachSubscriptionCallback): void;
-  detachSubscription(
-    name: string,
-    gaxOpts: CallOptions,
-    callback: DetachSubscriptionCallback
-  ): void;
   /**
    * Detach a subscription with the given name.
    *
@@ -690,6 +680,16 @@ export class PubSub {
    * });
    * ```
    */
+  detachSubscription(
+    name: string,
+    gaxOpts?: CallOptions
+  ): Promise<DetachSubscriptionResponse>;
+  detachSubscription(name: string, callback: DetachSubscriptionCallback): void;
+  detachSubscription(
+    name: string,
+    gaxOpts: CallOptions,
+    callback: DetachSubscriptionCallback
+  ): void;
   detachSubscription(
     name: string,
     optsOrCallback?: CallOptions | DetachSubscriptionCallback,
@@ -823,9 +823,6 @@ export class PubSub {
     }
   }
 
-  getSnapshots(options?: PageOptions): Promise<GetSnapshotsResponse>;
-  getSnapshots(callback: GetSnapshotsCallback): void;
-  getSnapshots(options: PageOptions, callback: GetSnapshotsCallback): void;
   /**
    * Query object for listing snapshots.
    *
@@ -874,6 +871,9 @@ export class PubSub {
    * });
    * ```
    */
+  getSnapshots(options?: PageOptions): Promise<GetSnapshotsResponse>;
+  getSnapshots(callback: GetSnapshotsCallback): void;
+  getSnapshots(options: PageOptions, callback: GetSnapshotsCallback): void;
   getSnapshots(
     optsOrCallback?: PageOptions | GetSnapshotsCallback,
     callback?: GetSnapshotsCallback
@@ -926,14 +926,6 @@ export class PubSub {
     );
   }
 
-  getSubscriptions(
-    options?: GetSubscriptionsOptions
-  ): Promise<GetSubscriptionsResponse>;
-  getSubscriptions(callback: GetSubscriptionsCallback): void;
-  getSubscriptions(
-    options: GetSubscriptionsOptions,
-    callback: GetSubscriptionsCallback
-  ): void;
   /**
    * Query object for listing subscriptions.
    *
@@ -994,6 +986,14 @@ export class PubSub {
    * ```
    */
   getSubscriptions(
+    options?: GetSubscriptionsOptions
+  ): Promise<GetSubscriptionsResponse>;
+  getSubscriptions(callback: GetSubscriptionsCallback): void;
+  getSubscriptions(
+    options: GetSubscriptionsOptions,
+    callback: GetSubscriptionsCallback
+  ): void;
+  getSubscriptions(
     optsOrCallback?: GetSubscriptionsOptions | GetSubscriptionsCallback,
     callback?: GetSubscriptionsCallback
   ): void | Promise<GetSubscriptionsResponse> {
@@ -1052,9 +1052,6 @@ export class PubSub {
     );
   }
 
-  getTopics(options?: PageOptions): Promise<GetTopicsResponse>;
-  getTopics(callback: GetTopicsCallback): void;
-  getTopics(options: PageOptions, callback: GetTopicsCallback): void;
   /**
    * Query object for listing topics.
    *
@@ -1113,6 +1110,9 @@ export class PubSub {
    * });
    * ```
    */
+  getTopics(options?: PageOptions): Promise<GetTopicsResponse>;
+  getTopics(callback: GetTopicsCallback): void;
+  getTopics(options: PageOptions, callback: GetTopicsCallback): void;
   getTopics(
     optsOrCallback?: PageOptions | GetTopicsCallback,
     callback?: GetTopicsCallback

--- a/src/pubsub.ts
+++ b/src/pubsub.ts
@@ -313,8 +313,6 @@ export class PubSub {
     return this.projectId.indexOf(PROJECT_ID_PLACEHOLDER) < 0;
   }
 
-  close(): Promise<void>;
-  close(callback: EmptyCallback): void;
   /**
    * Closes out this object, releasing any server connections. Note that once
    * you close a PubSub object, it may not be used again. Any pending operations
@@ -326,6 +324,8 @@ export class PubSub {
    * @callback EmptyCallback
    * @returns {Promise<void>}
    */
+  close(): Promise<void>;
+  close(callback: EmptyCallback): void;
   close(callback?: EmptyCallback): Promise<void> | void {
     const definedCallback = callback || (() => {});
     if (this.isOpen) {
@@ -395,22 +395,6 @@ export class PubSub {
     return new Schema(this, schemaName);
   }
 
-  createSubscription(
-    topic: Topic | string,
-    name: string,
-    options?: CreateSubscriptionOptions
-  ): Promise<CreateSubscriptionResponse>;
-  createSubscription(
-    topic: Topic | string,
-    name: string,
-    callback: CreateSubscriptionCallback
-  ): void;
-  createSubscription(
-    topic: Topic | string,
-    name: string,
-    options: CreateSubscriptionOptions,
-    callback: CreateSubscriptionCallback
-  ): void;
   /**
    * @typedef {array} CreateSubscriptionResponse
    * @property {Subscription} 0 The new {@link Subscription}.
@@ -498,6 +482,22 @@ export class PubSub {
   createSubscription(
     topic: Topic | string,
     name: string,
+    options?: CreateSubscriptionOptions
+  ): Promise<CreateSubscriptionResponse>;
+  createSubscription(
+    topic: Topic | string,
+    name: string,
+    callback: CreateSubscriptionCallback
+  ): void;
+  createSubscription(
+    topic: Topic | string,
+    name: string,
+    options: CreateSubscriptionOptions,
+    callback: CreateSubscriptionCallback
+  ): void;
+  createSubscription(
+    topic: Topic | string,
+    name: string,
     optionsOrCallback?: CreateSubscriptionOptions | CreateSubscriptionCallback,
     callback?: CreateSubscriptionCallback
   ): Promise<CreateSubscriptionResponse> | void {
@@ -556,19 +556,6 @@ export class PubSub {
     );
   }
 
-  createTopic(
-    name: string | TopicMetadata,
-    gaxOpts?: CallOptions
-  ): Promise<CreateTopicResponse>;
-  createTopic(
-    name: string | TopicMetadata,
-    callback: CreateTopicCallback
-  ): void;
-  createTopic(
-    name: string | TopicMetadata,
-    gaxOpts: CallOptions,
-    callback: CreateTopicCallback
-  ): void;
   /**
    * @typedef {array} CreateTopicResponse
    * @property {Topic} 0 The new {@link Topic}.
@@ -613,6 +600,19 @@ export class PubSub {
    */
   createTopic(
     name: string | TopicMetadata,
+    gaxOpts?: CallOptions
+  ): Promise<CreateTopicResponse>;
+  createTopic(
+    name: string | TopicMetadata,
+    callback: CreateTopicCallback
+  ): void;
+  createTopic(
+    name: string | TopicMetadata,
+    gaxOpts: CallOptions,
+    callback: CreateTopicCallback
+  ): void;
+  createTopic(
+    name: string | TopicMetadata,
     optsOrCallback?: CallOptions | CreateTopicCallback,
     callback?: CreateTopicCallback
   ): Promise<CreateTopicResponse> | void {
@@ -650,16 +650,6 @@ export class PubSub {
     );
   }
 
-  detachSubscription(
-    name: string,
-    gaxOpts?: CallOptions
-  ): Promise<DetachSubscriptionResponse>;
-  detachSubscription(name: string, callback: DetachSubscriptionCallback): void;
-  detachSubscription(
-    name: string,
-    gaxOpts: CallOptions,
-    callback: DetachSubscriptionCallback
-  ): void;
   /**
    * Detach a subscription with the given name.
    *
@@ -690,6 +680,16 @@ export class PubSub {
    * });
    * ```
    */
+  detachSubscription(
+    name: string,
+    gaxOpts?: CallOptions
+  ): Promise<DetachSubscriptionResponse>;
+  detachSubscription(name: string, callback: DetachSubscriptionCallback): void;
+  detachSubscription(
+    name: string,
+    gaxOpts: CallOptions,
+    callback: DetachSubscriptionCallback
+  ): void;
   detachSubscription(
     name: string,
     optsOrCallback?: CallOptions | DetachSubscriptionCallback,
@@ -823,9 +823,6 @@ export class PubSub {
     }
   }
 
-  getSnapshots(options?: PageOptions): Promise<GetSnapshotsResponse>;
-  getSnapshots(callback: GetSnapshotsCallback): void;
-  getSnapshots(options: PageOptions, callback: GetSnapshotsCallback): void;
   /**
    * Query object for listing snapshots.
    *
@@ -874,6 +871,9 @@ export class PubSub {
    * });
    * ```
    */
+  getSnapshots(options?: PageOptions): Promise<GetSnapshotsResponse>;
+  getSnapshots(callback: GetSnapshotsCallback): void;
+  getSnapshots(options: PageOptions, callback: GetSnapshotsCallback): void;
   getSnapshots(
     optsOrCallback?: PageOptions | GetSnapshotsCallback,
     callback?: GetSnapshotsCallback
@@ -926,14 +926,6 @@ export class PubSub {
     );
   }
 
-  getSubscriptions(
-    options?: GetSubscriptionsOptions
-  ): Promise<GetSubscriptionsResponse>;
-  getSubscriptions(callback: GetSubscriptionsCallback): void;
-  getSubscriptions(
-    options: GetSubscriptionsOptions,
-    callback: GetSubscriptionsCallback
-  ): void;
   /**
    * Query object for listing subscriptions.
    *
@@ -994,6 +986,14 @@ export class PubSub {
    * ```
    */
   getSubscriptions(
+    options?: GetSubscriptionsOptions
+  ): Promise<GetSubscriptionsResponse>;
+  getSubscriptions(callback: GetSubscriptionsCallback): void;
+  getSubscriptions(
+    options: GetSubscriptionsOptions,
+    callback: GetSubscriptionsCallback
+  ): void;
+  getSubscriptions(
     optsOrCallback?: GetSubscriptionsOptions | GetSubscriptionsCallback,
     callback?: GetSubscriptionsCallback
   ): void | Promise<GetSubscriptionsResponse> {
@@ -1052,9 +1052,6 @@ export class PubSub {
     );
   }
 
-  getTopics(options?: PageOptions): Promise<GetTopicsResponse>;
-  getTopics(callback: GetTopicsCallback): void;
-  getTopics(options: PageOptions, callback: GetTopicsCallback): void;
   /**
    * Query object for listing topics.
    *
@@ -1113,6 +1110,9 @@ export class PubSub {
    * });
    * ```
    */
+  getTopics(options?: PageOptions): Promise<GetTopicsResponse>;
+  getTopics(callback: GetTopicsCallback): void;
+  getTopics(options: PageOptions, callback: GetTopicsCallback): void;
   getTopics(
     optsOrCallback?: PageOptions | GetTopicsCallback,
     callback?: GetTopicsCallback
@@ -1566,12 +1566,3 @@ paginator.extend(PubSub, ['getSnapshots', 'getSubscriptions', 'getTopics']);
  * that a callback is omitted. Future methods will not allow for a callback.
  * (Use .then() on the returned Promise instead.)
  */
-promisifySome(PubSub, PubSub.prototype, [
-  'close',
-  'createSubscription',
-  'createTopic',
-  'detachSubscription',
-  'getSnapshots',
-  'getSubscriptions',
-  'getTopics',
-]);

--- a/src/pubsub.ts
+++ b/src/pubsub.ts
@@ -313,6 +313,8 @@ export class PubSub {
     return this.projectId.indexOf(PROJECT_ID_PLACEHOLDER) < 0;
   }
 
+  close(): Promise<void>;
+  close(callback: EmptyCallback): void;
   /**
    * Closes out this object, releasing any server connections. Note that once
    * you close a PubSub object, it may not be used again. Any pending operations
@@ -324,8 +326,6 @@ export class PubSub {
    * @callback EmptyCallback
    * @returns {Promise<void>}
    */
-  close(): Promise<void>;
-  close(callback: EmptyCallback): void;
   close(callback?: EmptyCallback): Promise<void> | void {
     const definedCallback = callback || (() => {});
     if (this.isOpen) {
@@ -395,6 +395,22 @@ export class PubSub {
     return new Schema(this, schemaName);
   }
 
+  createSubscription(
+    topic: Topic | string,
+    name: string,
+    options?: CreateSubscriptionOptions
+  ): Promise<CreateSubscriptionResponse>;
+  createSubscription(
+    topic: Topic | string,
+    name: string,
+    callback: CreateSubscriptionCallback
+  ): void;
+  createSubscription(
+    topic: Topic | string,
+    name: string,
+    options: CreateSubscriptionOptions,
+    callback: CreateSubscriptionCallback
+  ): void;
   /**
    * @typedef {array} CreateSubscriptionResponse
    * @property {Subscription} 0 The new {@link Subscription}.
@@ -482,22 +498,6 @@ export class PubSub {
   createSubscription(
     topic: Topic | string,
     name: string,
-    options?: CreateSubscriptionOptions
-  ): Promise<CreateSubscriptionResponse>;
-  createSubscription(
-    topic: Topic | string,
-    name: string,
-    callback: CreateSubscriptionCallback
-  ): void;
-  createSubscription(
-    topic: Topic | string,
-    name: string,
-    options: CreateSubscriptionOptions,
-    callback: CreateSubscriptionCallback
-  ): void;
-  createSubscription(
-    topic: Topic | string,
-    name: string,
     optionsOrCallback?: CreateSubscriptionOptions | CreateSubscriptionCallback,
     callback?: CreateSubscriptionCallback
   ): Promise<CreateSubscriptionResponse> | void {
@@ -556,6 +556,19 @@ export class PubSub {
     );
   }
 
+  createTopic(
+    name: string | TopicMetadata,
+    gaxOpts?: CallOptions
+  ): Promise<CreateTopicResponse>;
+  createTopic(
+    name: string | TopicMetadata,
+    callback: CreateTopicCallback
+  ): void;
+  createTopic(
+    name: string | TopicMetadata,
+    gaxOpts: CallOptions,
+    callback: CreateTopicCallback
+  ): void;
   /**
    * @typedef {array} CreateTopicResponse
    * @property {Topic} 0 The new {@link Topic}.
@@ -600,19 +613,6 @@ export class PubSub {
    */
   createTopic(
     name: string | TopicMetadata,
-    gaxOpts?: CallOptions
-  ): Promise<CreateTopicResponse>;
-  createTopic(
-    name: string | TopicMetadata,
-    callback: CreateTopicCallback
-  ): void;
-  createTopic(
-    name: string | TopicMetadata,
-    gaxOpts: CallOptions,
-    callback: CreateTopicCallback
-  ): void;
-  createTopic(
-    name: string | TopicMetadata,
     optsOrCallback?: CallOptions | CreateTopicCallback,
     callback?: CreateTopicCallback
   ): Promise<CreateTopicResponse> | void {
@@ -650,6 +650,16 @@ export class PubSub {
     );
   }
 
+  detachSubscription(
+    name: string,
+    gaxOpts?: CallOptions
+  ): Promise<DetachSubscriptionResponse>;
+  detachSubscription(name: string, callback: DetachSubscriptionCallback): void;
+  detachSubscription(
+    name: string,
+    gaxOpts: CallOptions,
+    callback: DetachSubscriptionCallback
+  ): void;
   /**
    * Detach a subscription with the given name.
    *
@@ -680,16 +690,6 @@ export class PubSub {
    * });
    * ```
    */
-  detachSubscription(
-    name: string,
-    gaxOpts?: CallOptions
-  ): Promise<DetachSubscriptionResponse>;
-  detachSubscription(name: string, callback: DetachSubscriptionCallback): void;
-  detachSubscription(
-    name: string,
-    gaxOpts: CallOptions,
-    callback: DetachSubscriptionCallback
-  ): void;
   detachSubscription(
     name: string,
     optsOrCallback?: CallOptions | DetachSubscriptionCallback,
@@ -823,6 +823,9 @@ export class PubSub {
     }
   }
 
+  getSnapshots(options?: PageOptions): Promise<GetSnapshotsResponse>;
+  getSnapshots(callback: GetSnapshotsCallback): void;
+  getSnapshots(options: PageOptions, callback: GetSnapshotsCallback): void;
   /**
    * Query object for listing snapshots.
    *
@@ -871,9 +874,6 @@ export class PubSub {
    * });
    * ```
    */
-  getSnapshots(options?: PageOptions): Promise<GetSnapshotsResponse>;
-  getSnapshots(callback: GetSnapshotsCallback): void;
-  getSnapshots(options: PageOptions, callback: GetSnapshotsCallback): void;
   getSnapshots(
     optsOrCallback?: PageOptions | GetSnapshotsCallback,
     callback?: GetSnapshotsCallback
@@ -926,6 +926,14 @@ export class PubSub {
     );
   }
 
+  getSubscriptions(
+    options?: GetSubscriptionsOptions
+  ): Promise<GetSubscriptionsResponse>;
+  getSubscriptions(callback: GetSubscriptionsCallback): void;
+  getSubscriptions(
+    options: GetSubscriptionsOptions,
+    callback: GetSubscriptionsCallback
+  ): void;
   /**
    * Query object for listing subscriptions.
    *
@@ -986,14 +994,6 @@ export class PubSub {
    * ```
    */
   getSubscriptions(
-    options?: GetSubscriptionsOptions
-  ): Promise<GetSubscriptionsResponse>;
-  getSubscriptions(callback: GetSubscriptionsCallback): void;
-  getSubscriptions(
-    options: GetSubscriptionsOptions,
-    callback: GetSubscriptionsCallback
-  ): void;
-  getSubscriptions(
     optsOrCallback?: GetSubscriptionsOptions | GetSubscriptionsCallback,
     callback?: GetSubscriptionsCallback
   ): void | Promise<GetSubscriptionsResponse> {
@@ -1052,6 +1052,9 @@ export class PubSub {
     );
   }
 
+  getTopics(options?: PageOptions): Promise<GetTopicsResponse>;
+  getTopics(callback: GetTopicsCallback): void;
+  getTopics(options: PageOptions, callback: GetTopicsCallback): void;
   /**
    * Query object for listing topics.
    *
@@ -1110,9 +1113,6 @@ export class PubSub {
    * });
    * ```
    */
-  getTopics(options?: PageOptions): Promise<GetTopicsResponse>;
-  getTopics(callback: GetTopicsCallback): void;
-  getTopics(options: PageOptions, callback: GetTopicsCallback): void;
   getTopics(
     optsOrCallback?: PageOptions | GetTopicsCallback,
     callback?: GetTopicsCallback
@@ -1566,3 +1566,12 @@ paginator.extend(PubSub, ['getSnapshots', 'getSubscriptions', 'getTopics']);
  * that a callback is omitted. Future methods will not allow for a callback.
  * (Use .then() on the returned Promise instead.)
  */
+promisifySome(PubSub, PubSub.prototype, [
+  'close',
+  'createSubscription',
+  'createTopic',
+  'detachSubscription',
+  'getSnapshots',
+  'getSubscriptions',
+  'getTopics',
+]);

--- a/src/snapshot.ts
+++ b/src/snapshot.ts
@@ -111,6 +111,8 @@ export class Snapshot {
     this.name = Snapshot.formatName_(parent.projectId, name);
   }
 
+  delete(): Promise<EmptyResponse>;
+  delete(callback: EmptyCallback): void;
   /**
    * Delete the snapshot.
    *
@@ -132,8 +134,6 @@ export class Snapshot {
    * });
    * ```
    */
-  delete(): Promise<EmptyResponse>;
-  delete(callback: EmptyCallback): void;
   delete(callback?: EmptyCallback): void | Promise<EmptyResponse> {
     const reqOpts = {
       snapshot: this.name,
@@ -159,6 +159,9 @@ export class Snapshot {
     return 'projects/' + projectId + '/snapshots/' + name.split('/').pop();
   }
 
+  create(gaxOpts?: CallOptions): Promise<CreateSnapshotResponse>;
+  create(callback: CreateSnapshotCallback): void;
+  create(gaxOpts: CallOptions, callback: CreateSnapshotCallback): void;
   /**
    * Create a snapshot with the given name.
    *
@@ -196,9 +199,6 @@ export class Snapshot {
    * });
    * ```
    */
-  create(gaxOpts?: CallOptions): Promise<CreateSnapshotResponse>;
-  create(callback: CreateSnapshotCallback): void;
-  create(gaxOpts: CallOptions, callback: CreateSnapshotCallback): void;
   create(
     optsOrCallback?: CallOptions | CreateSnapshotCallback,
     callback?: CreateSnapshotCallback
@@ -226,6 +226,9 @@ export class Snapshot {
     );
   }
 
+  seek(gaxOpts?: CallOptions): Promise<SeekResponse>;
+  seek(callback: SeekCallback): void;
+  seek(gaxOpts: CallOptions, callback: SeekCallback): void;
   /**
    * Seeks an existing subscription to the snapshot.
    *
@@ -253,9 +256,6 @@ export class Snapshot {
    * });
    * ```
    */
-  seek(gaxOpts?: CallOptions): Promise<SeekResponse>;
-  seek(callback: SeekCallback): void;
-  seek(gaxOpts: CallOptions, callback: SeekCallback): void;
   seek(
     gaxOpts?: CallOptions | SeekCallback,
     callback?: SeekCallback

--- a/src/snapshot.ts
+++ b/src/snapshot.ts
@@ -111,8 +111,6 @@ export class Snapshot {
     this.name = Snapshot.formatName_(parent.projectId, name);
   }
 
-  delete(): Promise<EmptyResponse>;
-  delete(callback: EmptyCallback): void;
   /**
    * Delete the snapshot.
    *
@@ -134,6 +132,8 @@ export class Snapshot {
    * });
    * ```
    */
+  delete(): Promise<EmptyResponse>;
+  delete(callback: EmptyCallback): void;
   delete(callback?: EmptyCallback): void | Promise<EmptyResponse> {
     const reqOpts = {
       snapshot: this.name,
@@ -159,9 +159,6 @@ export class Snapshot {
     return 'projects/' + projectId + '/snapshots/' + name.split('/').pop();
   }
 
-  create(gaxOpts?: CallOptions): Promise<CreateSnapshotResponse>;
-  create(callback: CreateSnapshotCallback): void;
-  create(gaxOpts: CallOptions, callback: CreateSnapshotCallback): void;
   /**
    * Create a snapshot with the given name.
    *
@@ -199,6 +196,9 @@ export class Snapshot {
    * });
    * ```
    */
+  create(gaxOpts?: CallOptions): Promise<CreateSnapshotResponse>;
+  create(callback: CreateSnapshotCallback): void;
+  create(gaxOpts: CallOptions, callback: CreateSnapshotCallback): void;
   create(
     optsOrCallback?: CallOptions | CreateSnapshotCallback,
     callback?: CreateSnapshotCallback
@@ -226,9 +226,6 @@ export class Snapshot {
     );
   }
 
-  seek(gaxOpts?: CallOptions): Promise<SeekResponse>;
-  seek(callback: SeekCallback): void;
-  seek(gaxOpts: CallOptions, callback: SeekCallback): void;
   /**
    * Seeks an existing subscription to the snapshot.
    *
@@ -256,6 +253,9 @@ export class Snapshot {
    * });
    * ```
    */
+  seek(gaxOpts?: CallOptions): Promise<SeekResponse>;
+  seek(callback: SeekCallback): void;
+  seek(gaxOpts: CallOptions, callback: SeekCallback): void;
   seek(
     gaxOpts?: CallOptions | SeekCallback,
     callback?: SeekCallback

--- a/src/subscription.ts
+++ b/src/subscription.ts
@@ -340,6 +340,8 @@ export class Subscription extends EventEmitter {
     return (this.pubsub && this.pubsub.projectId) || '{{projectId}}';
   }
 
+  close(): Promise<void>;
+  close(callback: SubscriptionCloseCallback): void;
   /**
    * Closes the Subscription, once this is called you will no longer receive
    * message events unless you call {Subscription#open} or add new message
@@ -361,12 +363,18 @@ export class Subscription extends EventEmitter {
    * subscription.close().then(() => {});
    * ```
    */
-  close(): Promise<void>;
-  close(callback: SubscriptionCloseCallback): void;
   close(callback?: SubscriptionCloseCallback): void | Promise<void> {
     this._subscriber.close().then(() => callback!(), callback);
   }
 
+  create(
+    options?: CreateSubscriptionOptions
+  ): Promise<CreateSubscriptionResponse>;
+  create(callback: CreateSubscriptionCallback): void;
+  create(
+    options: CreateSubscriptionOptions,
+    callback: CreateSubscriptionCallback
+  ): void;
   /**
    * Create a subscription.
    *
@@ -406,14 +414,6 @@ export class Subscription extends EventEmitter {
    * ```
    */
   create(
-    options?: CreateSubscriptionOptions
-  ): Promise<CreateSubscriptionResponse>;
-  create(callback: CreateSubscriptionCallback): void;
-  create(
-    options: CreateSubscriptionOptions,
-    callback: CreateSubscriptionCallback
-  ): void;
-  create(
     optsOrCallback?: CreateSubscriptionOptions | CreateSubscriptionCallback,
     callback?: CreateSubscriptionCallback
   ): void | Promise<CreateSubscriptionResponse> {
@@ -442,6 +442,16 @@ export class Subscription extends EventEmitter {
     );
   }
 
+  createSnapshot(
+    name: string,
+    gaxOpts?: CallOptions
+  ): Promise<CreateSnapshotResponse>;
+  createSnapshot(name: string, callback: CreateSnapshotCallback): void;
+  createSnapshot(
+    name: string,
+    gaxOpts: CallOptions,
+    callback: CreateSnapshotCallback
+  ): void;
   /**
    * @typedef {array} CreateSnapshotResponse
    * @property {Snapshot} 0 The new {@link Snapshot}.
@@ -489,16 +499,6 @@ export class Subscription extends EventEmitter {
    */
   createSnapshot(
     name: string,
-    gaxOpts?: CallOptions
-  ): Promise<CreateSnapshotResponse>;
-  createSnapshot(name: string, callback: CreateSnapshotCallback): void;
-  createSnapshot(
-    name: string,
-    gaxOpts: CallOptions,
-    callback: CreateSnapshotCallback
-  ): void;
-  createSnapshot(
-    name: string,
     optsOrCallback?: CallOptions | CreateSnapshotCallback,
     callback?: CreateSnapshotCallback
   ): void | Promise<CreateSnapshotResponse> {
@@ -531,6 +531,9 @@ export class Subscription extends EventEmitter {
     );
   }
 
+  delete(gaxOpts?: CallOptions): Promise<EmptyResponse>;
+  delete(callback: EmptyCallback): void;
+  delete(gaxOpts: CallOptions, callback: EmptyCallback): void;
   /**
    * Delete the subscription. Pull requests from the current subscription will
    * be errored once unsubscription is complete.
@@ -562,9 +565,6 @@ export class Subscription extends EventEmitter {
    * });
    * ```
    */
-  delete(gaxOpts?: CallOptions): Promise<EmptyResponse>;
-  delete(callback: EmptyCallback): void;
-  delete(gaxOpts: CallOptions, callback: EmptyCallback): void;
   delete(
     optsOrCallback?: CallOptions | EmptyCallback,
     callback?: EmptyCallback
@@ -591,6 +591,8 @@ export class Subscription extends EventEmitter {
     );
   }
 
+  detached(): Promise<DetachedResponse>;
+  detached(callback: DetachedCallback): void;
   /**
    * @typedef {array} SubscriptionDetachedResponse
    * @property {boolean} 0 Whether the subscription is detached.
@@ -624,8 +626,6 @@ export class Subscription extends EventEmitter {
    * });
    * ```
    */
-  detached(): Promise<DetachedResponse>;
-  detached(callback: DetachedCallback): void;
   detached(callback?: DetachedCallback): void | Promise<DetachedResponse> {
     this.getMetadata((err, metadata) => {
       if (err) {
@@ -636,6 +636,8 @@ export class Subscription extends EventEmitter {
     });
   }
 
+  exists(): Promise<ExistsResponse>;
+  exists(callback: ExistsCallback): void;
   /**
    * @typedef {array} SubscriptionExistsResponse
    * @property {boolean} 0 Whether the subscription exists
@@ -669,8 +671,6 @@ export class Subscription extends EventEmitter {
    * });
    * ```
    */
-  exists(): Promise<ExistsResponse>;
-  exists(callback: ExistsCallback): void;
   exists(callback?: ExistsCallback): void | Promise<ExistsResponse> {
     this.getMetadata(err => {
       if (!err) {
@@ -686,6 +686,9 @@ export class Subscription extends EventEmitter {
     });
   }
 
+  get(gaxOpts?: GetSubscriptionOptions): Promise<GetSubscriptionResponse>;
+  get(callback: GetSubscriptionCallback): void;
+  get(gaxOpts: GetSubscriptionOptions, callback: GetSubscriptionCallback): void;
   /**
    * @typedef {array} GetSubscriptionResponse
    * @property {Subscription} 0 The {@link Subscription}.
@@ -728,9 +731,6 @@ export class Subscription extends EventEmitter {
    * });
    * ```
    */
-  get(gaxOpts?: GetSubscriptionOptions): Promise<GetSubscriptionResponse>;
-  get(callback: GetSubscriptionCallback): void;
-  get(gaxOpts: GetSubscriptionOptions, callback: GetSubscriptionCallback): void;
   get(
     optsOrCallback?: GetSubscriptionOptions | GetSubscriptionCallback,
     callback?: GetSubscriptionCallback
@@ -756,6 +756,12 @@ export class Subscription extends EventEmitter {
     });
   }
 
+  getMetadata(gaxOpts?: CallOptions): Promise<GetSubscriptionMetadataResponse>;
+  getMetadata(callback: GetSubscriptionMetadataCallback): void;
+  getMetadata(
+    gaxOpts: CallOptions,
+    callback: GetSubscriptionMetadataCallback
+  ): void;
   /**
    * @typedef {array} GetSubscriptionMetadataResponse
    * @property {object} 0 The full API response.
@@ -795,12 +801,6 @@ export class Subscription extends EventEmitter {
    * });
    * ```
    */
-  getMetadata(gaxOpts?: CallOptions): Promise<GetSubscriptionMetadataResponse>;
-  getMetadata(callback: GetSubscriptionMetadataCallback): void;
-  getMetadata(
-    gaxOpts: CallOptions,
-    callback: GetSubscriptionMetadataCallback
-  ): void;
   getMetadata(
     optsOrCallback?: CallOptions | GetSubscriptionMetadataCallback,
     callback?: GetSubscriptionMetadataCallback
@@ -828,6 +828,16 @@ export class Subscription extends EventEmitter {
     );
   }
 
+  modifyPushConfig(
+    config: PushConfig,
+    gaxOpts?: CallOptions
+  ): Promise<EmptyResponse>;
+  modifyPushConfig(config: PushConfig, callback: EmptyCallback): void;
+  modifyPushConfig(
+    config: PushConfig,
+    gaxOpts: CallOptions,
+    callback: EmptyCallback
+  ): void;
   /**
    * @typedef {array} ModifyPushConfigResponse
    * @property {object} 0 The full API response.
@@ -888,16 +898,6 @@ export class Subscription extends EventEmitter {
    */
   modifyPushConfig(
     config: PushConfig,
-    gaxOpts?: CallOptions
-  ): Promise<EmptyResponse>;
-  modifyPushConfig(config: PushConfig, callback: EmptyCallback): void;
-  modifyPushConfig(
-    config: PushConfig,
-    gaxOpts: CallOptions,
-    callback: EmptyCallback
-  ): void;
-  modifyPushConfig(
-    config: PushConfig,
     optsOrCallback?: CallOptions | EmptyCallback,
     callback?: EmptyCallback
   ): void | Promise<EmptyResponse> {
@@ -949,6 +949,13 @@ export class Subscription extends EventEmitter {
     }
   }
 
+  seek(snapshot: string | Date, gaxOpts?: CallOptions): Promise<SeekResponse>;
+  seek(snapshot: string | Date, callback: SeekCallback): void;
+  seek(
+    snapshot: string | Date,
+    gaxOpts: CallOptions,
+    callback: SeekCallback
+  ): void;
   /**
    * @typedef {array} SeekResponse
    * @property {object} 0 The full API response.
@@ -988,13 +995,6 @@ export class Subscription extends EventEmitter {
    * subscription.seek(date, callback);
    * ```
    */
-  seek(snapshot: string | Date, gaxOpts?: CallOptions): Promise<SeekResponse>;
-  seek(snapshot: string | Date, callback: SeekCallback): void;
-  seek(
-    snapshot: string | Date,
-    gaxOpts: CallOptions,
-    callback: SeekCallback
-  ): void;
   seek(
     snapshot: string | Date,
     optsOrCallback?: CallOptions | SeekCallback,
@@ -1030,6 +1030,19 @@ export class Subscription extends EventEmitter {
     );
   }
 
+  setMetadata(
+    metadata: SubscriptionMetadata,
+    gaxOpts?: CallOptions
+  ): Promise<SetSubscriptionMetadataResponse>;
+  setMetadata(
+    metadata: SubscriptionMetadata,
+    callback: SetSubscriptionMetadataCallback
+  ): void;
+  setMetadata(
+    metadata: SubscriptionMetadata,
+    gaxOpts: CallOptions,
+    callback: SetSubscriptionMetadataCallback
+  ): void;
   /**
    * @typedef {array} SetSubscriptionMetadataResponse
    * @property {object} 0 The full API response.
@@ -1068,19 +1081,6 @@ export class Subscription extends EventEmitter {
    * });
    * ```
    */
-  setMetadata(
-    metadata: SubscriptionMetadata,
-    gaxOpts?: CallOptions
-  ): Promise<SetSubscriptionMetadataResponse>;
-  setMetadata(
-    metadata: SubscriptionMetadata,
-    callback: SetSubscriptionMetadataCallback
-  ): void;
-  setMetadata(
-    metadata: SubscriptionMetadata,
-    gaxOpts: CallOptions,
-    callback: SetSubscriptionMetadataCallback
-  ): void;
   setMetadata(
     metadata: SubscriptionMetadata,
     optsOrCallback?: CallOptions | SetSubscriptionMetadataCallback,

--- a/src/subscription.ts
+++ b/src/subscription.ts
@@ -340,8 +340,6 @@ export class Subscription extends EventEmitter {
     return (this.pubsub && this.pubsub.projectId) || '{{projectId}}';
   }
 
-  close(): Promise<void>;
-  close(callback: SubscriptionCloseCallback): void;
   /**
    * Closes the Subscription, once this is called you will no longer receive
    * message events unless you call {Subscription#open} or add new message
@@ -363,18 +361,12 @@ export class Subscription extends EventEmitter {
    * subscription.close().then(() => {});
    * ```
    */
+  close(): Promise<void>;
+  close(callback: SubscriptionCloseCallback): void;
   close(callback?: SubscriptionCloseCallback): void | Promise<void> {
     this._subscriber.close().then(() => callback!(), callback);
   }
 
-  create(
-    options?: CreateSubscriptionOptions
-  ): Promise<CreateSubscriptionResponse>;
-  create(callback: CreateSubscriptionCallback): void;
-  create(
-    options: CreateSubscriptionOptions,
-    callback: CreateSubscriptionCallback
-  ): void;
   /**
    * Create a subscription.
    *
@@ -414,6 +406,14 @@ export class Subscription extends EventEmitter {
    * ```
    */
   create(
+    options?: CreateSubscriptionOptions
+  ): Promise<CreateSubscriptionResponse>;
+  create(callback: CreateSubscriptionCallback): void;
+  create(
+    options: CreateSubscriptionOptions,
+    callback: CreateSubscriptionCallback
+  ): void;
+  create(
     optsOrCallback?: CreateSubscriptionOptions | CreateSubscriptionCallback,
     callback?: CreateSubscriptionCallback
   ): void | Promise<CreateSubscriptionResponse> {
@@ -442,16 +442,6 @@ export class Subscription extends EventEmitter {
     );
   }
 
-  createSnapshot(
-    name: string,
-    gaxOpts?: CallOptions
-  ): Promise<CreateSnapshotResponse>;
-  createSnapshot(name: string, callback: CreateSnapshotCallback): void;
-  createSnapshot(
-    name: string,
-    gaxOpts: CallOptions,
-    callback: CreateSnapshotCallback
-  ): void;
   /**
    * @typedef {array} CreateSnapshotResponse
    * @property {Snapshot} 0 The new {@link Snapshot}.
@@ -499,6 +489,16 @@ export class Subscription extends EventEmitter {
    */
   createSnapshot(
     name: string,
+    gaxOpts?: CallOptions
+  ): Promise<CreateSnapshotResponse>;
+  createSnapshot(name: string, callback: CreateSnapshotCallback): void;
+  createSnapshot(
+    name: string,
+    gaxOpts: CallOptions,
+    callback: CreateSnapshotCallback
+  ): void;
+  createSnapshot(
+    name: string,
     optsOrCallback?: CallOptions | CreateSnapshotCallback,
     callback?: CreateSnapshotCallback
   ): void | Promise<CreateSnapshotResponse> {
@@ -531,9 +531,6 @@ export class Subscription extends EventEmitter {
     );
   }
 
-  delete(gaxOpts?: CallOptions): Promise<EmptyResponse>;
-  delete(callback: EmptyCallback): void;
-  delete(gaxOpts: CallOptions, callback: EmptyCallback): void;
   /**
    * Delete the subscription. Pull requests from the current subscription will
    * be errored once unsubscription is complete.
@@ -565,6 +562,9 @@ export class Subscription extends EventEmitter {
    * });
    * ```
    */
+  delete(gaxOpts?: CallOptions): Promise<EmptyResponse>;
+  delete(callback: EmptyCallback): void;
+  delete(gaxOpts: CallOptions, callback: EmptyCallback): void;
   delete(
     optsOrCallback?: CallOptions | EmptyCallback,
     callback?: EmptyCallback
@@ -591,8 +591,6 @@ export class Subscription extends EventEmitter {
     );
   }
 
-  detached(): Promise<DetachedResponse>;
-  detached(callback: DetachedCallback): void;
   /**
    * @typedef {array} SubscriptionDetachedResponse
    * @property {boolean} 0 Whether the subscription is detached.
@@ -626,6 +624,8 @@ export class Subscription extends EventEmitter {
    * });
    * ```
    */
+  detached(): Promise<DetachedResponse>;
+  detached(callback: DetachedCallback): void;
   detached(callback?: DetachedCallback): void | Promise<DetachedResponse> {
     this.getMetadata((err, metadata) => {
       if (err) {
@@ -636,8 +636,6 @@ export class Subscription extends EventEmitter {
     });
   }
 
-  exists(): Promise<ExistsResponse>;
-  exists(callback: ExistsCallback): void;
   /**
    * @typedef {array} SubscriptionExistsResponse
    * @property {boolean} 0 Whether the subscription exists
@@ -671,6 +669,8 @@ export class Subscription extends EventEmitter {
    * });
    * ```
    */
+  exists(): Promise<ExistsResponse>;
+  exists(callback: ExistsCallback): void;
   exists(callback?: ExistsCallback): void | Promise<ExistsResponse> {
     this.getMetadata(err => {
       if (!err) {
@@ -686,9 +686,6 @@ export class Subscription extends EventEmitter {
     });
   }
 
-  get(gaxOpts?: GetSubscriptionOptions): Promise<GetSubscriptionResponse>;
-  get(callback: GetSubscriptionCallback): void;
-  get(gaxOpts: GetSubscriptionOptions, callback: GetSubscriptionCallback): void;
   /**
    * @typedef {array} GetSubscriptionResponse
    * @property {Subscription} 0 The {@link Subscription}.
@@ -731,6 +728,9 @@ export class Subscription extends EventEmitter {
    * });
    * ```
    */
+  get(gaxOpts?: GetSubscriptionOptions): Promise<GetSubscriptionResponse>;
+  get(callback: GetSubscriptionCallback): void;
+  get(gaxOpts: GetSubscriptionOptions, callback: GetSubscriptionCallback): void;
   get(
     optsOrCallback?: GetSubscriptionOptions | GetSubscriptionCallback,
     callback?: GetSubscriptionCallback
@@ -756,12 +756,6 @@ export class Subscription extends EventEmitter {
     });
   }
 
-  getMetadata(gaxOpts?: CallOptions): Promise<GetSubscriptionMetadataResponse>;
-  getMetadata(callback: GetSubscriptionMetadataCallback): void;
-  getMetadata(
-    gaxOpts: CallOptions,
-    callback: GetSubscriptionMetadataCallback
-  ): void;
   /**
    * @typedef {array} GetSubscriptionMetadataResponse
    * @property {object} 0 The full API response.
@@ -801,6 +795,12 @@ export class Subscription extends EventEmitter {
    * });
    * ```
    */
+  getMetadata(gaxOpts?: CallOptions): Promise<GetSubscriptionMetadataResponse>;
+  getMetadata(callback: GetSubscriptionMetadataCallback): void;
+  getMetadata(
+    gaxOpts: CallOptions,
+    callback: GetSubscriptionMetadataCallback
+  ): void;
   getMetadata(
     optsOrCallback?: CallOptions | GetSubscriptionMetadataCallback,
     callback?: GetSubscriptionMetadataCallback
@@ -828,16 +828,6 @@ export class Subscription extends EventEmitter {
     );
   }
 
-  modifyPushConfig(
-    config: PushConfig,
-    gaxOpts?: CallOptions
-  ): Promise<EmptyResponse>;
-  modifyPushConfig(config: PushConfig, callback: EmptyCallback): void;
-  modifyPushConfig(
-    config: PushConfig,
-    gaxOpts: CallOptions,
-    callback: EmptyCallback
-  ): void;
   /**
    * @typedef {array} ModifyPushConfigResponse
    * @property {object} 0 The full API response.
@@ -898,6 +888,16 @@ export class Subscription extends EventEmitter {
    */
   modifyPushConfig(
     config: PushConfig,
+    gaxOpts?: CallOptions
+  ): Promise<EmptyResponse>;
+  modifyPushConfig(config: PushConfig, callback: EmptyCallback): void;
+  modifyPushConfig(
+    config: PushConfig,
+    gaxOpts: CallOptions,
+    callback: EmptyCallback
+  ): void;
+  modifyPushConfig(
+    config: PushConfig,
     optsOrCallback?: CallOptions | EmptyCallback,
     callback?: EmptyCallback
   ): void | Promise<EmptyResponse> {
@@ -949,13 +949,6 @@ export class Subscription extends EventEmitter {
     }
   }
 
-  seek(snapshot: string | Date, gaxOpts?: CallOptions): Promise<SeekResponse>;
-  seek(snapshot: string | Date, callback: SeekCallback): void;
-  seek(
-    snapshot: string | Date,
-    gaxOpts: CallOptions,
-    callback: SeekCallback
-  ): void;
   /**
    * @typedef {array} SeekResponse
    * @property {object} 0 The full API response.
@@ -995,6 +988,13 @@ export class Subscription extends EventEmitter {
    * subscription.seek(date, callback);
    * ```
    */
+  seek(snapshot: string | Date, gaxOpts?: CallOptions): Promise<SeekResponse>;
+  seek(snapshot: string | Date, callback: SeekCallback): void;
+  seek(
+    snapshot: string | Date,
+    gaxOpts: CallOptions,
+    callback: SeekCallback
+  ): void;
   seek(
     snapshot: string | Date,
     optsOrCallback?: CallOptions | SeekCallback,
@@ -1030,19 +1030,6 @@ export class Subscription extends EventEmitter {
     );
   }
 
-  setMetadata(
-    metadata: SubscriptionMetadata,
-    gaxOpts?: CallOptions
-  ): Promise<SetSubscriptionMetadataResponse>;
-  setMetadata(
-    metadata: SubscriptionMetadata,
-    callback: SetSubscriptionMetadataCallback
-  ): void;
-  setMetadata(
-    metadata: SubscriptionMetadata,
-    gaxOpts: CallOptions,
-    callback: SetSubscriptionMetadataCallback
-  ): void;
   /**
    * @typedef {array} SetSubscriptionMetadataResponse
    * @property {object} 0 The full API response.
@@ -1081,6 +1068,19 @@ export class Subscription extends EventEmitter {
    * });
    * ```
    */
+  setMetadata(
+    metadata: SubscriptionMetadata,
+    gaxOpts?: CallOptions
+  ): Promise<SetSubscriptionMetadataResponse>;
+  setMetadata(
+    metadata: SubscriptionMetadata,
+    callback: SetSubscriptionMetadataCallback
+  ): void;
+  setMetadata(
+    metadata: SubscriptionMetadata,
+    gaxOpts: CallOptions,
+    callback: SetSubscriptionMetadataCallback
+  ): void;
   setMetadata(
     metadata: SubscriptionMetadata,
     optsOrCallback?: CallOptions | SetSubscriptionMetadataCallback,

--- a/src/topic.ts
+++ b/src/topic.ts
@@ -182,6 +182,8 @@ export class Topic {
     this.iam = new IAM(pubsub, this.name);
   }
 
+  flush(): Promise<void>;
+  flush(callback: EmptyCallback): void;
   /**
    * Immediately sends all remaining queued data. This is mostly useful
    * if you are planning to call close() on the PubSub object that holds
@@ -190,14 +192,15 @@ export class Topic {
    * @param {EmptyCallback} [callback] Callback function.
    * @returns {Promise<EmptyResponse>}
    */
-  flush(): Promise<void>;
-  flush(callback: EmptyCallback): void;
   flush(callback?: EmptyCallback): Promise<void> | void {
     // It doesn't matter here if callback is undefined; the Publisher
     // flush() will handle it.
     this.publisher.flush(callback!);
   }
 
+  create(gaxOpts?: CallOptions): Promise<CreateTopicResponse>;
+  create(callback: CreateTopicCallback): void;
+  create(gaxOpts: CallOptions, callback: CreateTopicCallback): void;
   /**
    * Create a topic.
    *
@@ -228,9 +231,6 @@ export class Topic {
    * });
    * ```
    */
-  create(gaxOpts?: CallOptions): Promise<CreateTopicResponse>;
-  create(callback: CreateTopicCallback): void;
-  create(gaxOpts: CallOptions, callback: CreateTopicCallback): void;
   create(
     optsOrCallback?: CallOptions | CreateTopicCallback,
     callback?: CreateTopicCallback
@@ -241,6 +241,16 @@ export class Topic {
     this.pubsub.createTopic(this.name, gaxOpts, callback!);
   }
 
+  createSubscription(name: string, callback: CreateSubscriptionCallback): void;
+  createSubscription(
+    name: string,
+    options?: CreateSubscriptionOptions
+  ): Promise<CreateSubscriptionResponse>;
+  createSubscription(
+    name: string,
+    options: CreateSubscriptionOptions,
+    callback: CreateSubscriptionCallback
+  ): void;
   /**
    * Create a subscription to this topic.
    *
@@ -280,16 +290,6 @@ export class Topic {
    * });
    * ```
    */
-  createSubscription(name: string, callback: CreateSubscriptionCallback): void;
-  createSubscription(
-    name: string,
-    options?: CreateSubscriptionOptions
-  ): Promise<CreateSubscriptionResponse>;
-  createSubscription(
-    name: string,
-    options: CreateSubscriptionOptions,
-    callback: CreateSubscriptionCallback
-  ): void;
   createSubscription(
     name: string,
     optsOrCallback?: CreateSubscriptionOptions | CreateSubscriptionCallback,
@@ -306,6 +306,9 @@ export class Topic {
     );
   }
 
+  delete(callback: EmptyCallback): void;
+  delete(gaxOpts?: CallOptions): Promise<EmptyResponse>;
+  delete(gaxOpts: CallOptions, callback: EmptyCallback): void;
   /**
    * Delete the topic. This will not delete subscriptions to this topic.
    *
@@ -335,9 +338,6 @@ export class Topic {
    * });
    * ```
    */
-  delete(callback: EmptyCallback): void;
-  delete(gaxOpts?: CallOptions): Promise<EmptyResponse>;
-  delete(gaxOpts: CallOptions, callback: EmptyCallback): void;
   delete(
     optsOrCallback?: CallOptions | EmptyCallback,
     callback?: EmptyCallback
@@ -360,6 +360,8 @@ export class Topic {
     );
   }
 
+  exists(): Promise<ExistsResponse>;
+  exists(callback: ExistsCallback): void;
   /**
    * @typedef {array} TopicExistsResponse
    * @property {boolean} 0 Whether the topic exists
@@ -392,8 +394,6 @@ export class Topic {
    * });
    * ```
    */
-  exists(): Promise<ExistsResponse>;
-  exists(callback: ExistsCallback): void;
   exists(callback?: ExistsCallback): void | Promise<ExistsResponse> {
     this.getMetadata(err => {
       if (!err) {
@@ -408,6 +408,9 @@ export class Topic {
     });
   }
 
+  get(callback: GetTopicCallback): void;
+  get(gaxOpts?: GetTopicOptions): Promise<GetTopicResponse>;
+  get(gaxOpts: GetTopicOptions, callback: GetTopicCallback): void;
   /**
    * @typedef {array} GetTopicResponse
    * @property {Topic} 0 The {@link Topic}.
@@ -449,9 +452,6 @@ export class Topic {
    * });
    * ```
    */
-  get(callback: GetTopicCallback): void;
-  get(gaxOpts?: GetTopicOptions): Promise<GetTopicResponse>;
-  get(gaxOpts: GetTopicOptions, callback: GetTopicCallback): void;
   get(
     optsOrCallback?: GetTopicOptions | GetTopicCallback,
     callback?: GetTopicCallback
@@ -475,6 +475,9 @@ export class Topic {
     });
   }
 
+  getMetadata(callback: GetTopicMetadataCallback): void;
+  getMetadata(gaxOpts: CallOptions, callback: GetTopicMetadataCallback): void;
+  getMetadata(gaxOpts?: CallOptions): Promise<GetTopicMetadataResponse>;
   /**
    * @typedef {array} GetTopicMetadataResponse
    * @property {object} 0 The full API response.
@@ -511,9 +514,6 @@ export class Topic {
    * });
    * ```
    */
-  getMetadata(callback: GetTopicMetadataCallback): void;
-  getMetadata(gaxOpts: CallOptions, callback: GetTopicMetadataCallback): void;
-  getMetadata(gaxOpts?: CallOptions): Promise<GetTopicMetadataResponse>;
   getMetadata(
     optsOrCallback?: CallOptions | GetTopicMetadataCallback,
     callback?: GetTopicMetadataCallback
@@ -541,6 +541,14 @@ export class Topic {
     );
   }
 
+  getSubscriptions(callback: GetTopicSubscriptionsCallback): void;
+  getSubscriptions(
+    options: PageOptions,
+    callback: GetTopicSubscriptionsCallback
+  ): void;
+  getSubscriptions(
+    options?: PageOptions
+  ): Promise<GetTopicSubscriptionsResponse>;
   /**
    * Get a list of the subscriptions registered to this topic. You may
    * optionally provide a query object as the first argument to customize the
@@ -579,14 +587,6 @@ export class Topic {
    * });
    * ```
    */
-  getSubscriptions(callback: GetTopicSubscriptionsCallback): void;
-  getSubscriptions(
-    options: PageOptions,
-    callback: GetTopicSubscriptionsCallback
-  ): void;
-  getSubscriptions(
-    options?: PageOptions
-  ): Promise<GetTopicSubscriptionsResponse>;
   getSubscriptions(
     optsOrCallback?: PageOptions | GetTopicSubscriptionsCallback,
     callback?: GetTopicSubscriptionsCallback
@@ -631,6 +631,13 @@ export class Topic {
     );
   }
 
+  publish(data: Buffer, attributes?: Attributes): Promise<string>;
+  publish(data: Buffer, callback: PublishCallback): void;
+  publish(
+    data: Buffer,
+    attributes: Attributes,
+    callback: PublishCallback
+  ): void;
   /**
    * Publish the provided message.
    *
@@ -676,13 +683,6 @@ export class Topic {
    * topic.publish(data).then((messageId) => {});
    * ```
    */
-  publish(data: Buffer, attributes?: Attributes): Promise<string>;
-  publish(data: Buffer, callback: PublishCallback): void;
-  publish(
-    data: Buffer,
-    attributes: Attributes,
-    callback: PublishCallback
-  ): void;
   publish(
     data: Buffer,
     attrsOrCb?: Attributes | PublishCallback,
@@ -693,6 +693,13 @@ export class Topic {
     return this.publishMessage({data, attributes}, callback!);
   }
 
+  publishJSON(json: object, attributes?: Attributes): Promise<string>;
+  publishJSON(json: object, callback: PublishCallback): void;
+  publishJSON(
+    json: object,
+    attributes: Attributes,
+    callback: PublishCallback
+  ): void;
   /**
    * Publish the provided JSON. It should be noted that all messages published
    * are done so in the form of a Buffer. This is simply a convenience method
@@ -742,13 +749,6 @@ export class Topic {
    * topic.publishJSON(data).then((messageId) => {});
    * ```
    */
-  publishJSON(json: object, attributes?: Attributes): Promise<string>;
-  publishJSON(json: object, callback: PublishCallback): void;
-  publishJSON(
-    json: object,
-    attributes: Attributes,
-    callback: PublishCallback
-  ): void;
   publishJSON(
     json: object,
     attrsOrCb?: Attributes | PublishCallback,
@@ -763,6 +763,8 @@ export class Topic {
     return this.publishMessage({json, attributes}, callback!);
   }
 
+  publishMessage(message: MessageOptions): Promise<[string]>;
+  publishMessage(message: MessageOptions, callback: PublishCallback): void;
   /**
    * @typedef {object} MessageOptions
    * @property {buffer} [data] The message data.
@@ -822,8 +824,6 @@ export class Topic {
    * const [messageId] = await topic.publishMessage({data});
    * ```
    */
-  publishMessage(message: MessageOptions): Promise<[string]>;
-  publishMessage(message: MessageOptions, callback: PublishCallback): void;
   publishMessage(
     message: MessageOptions,
     callback?: PublishCallback
@@ -885,6 +885,16 @@ export class Topic {
     this.publisher.resumePublishing(orderingKey);
   }
 
+  setMetadata(
+    options: TopicMetadata,
+    gaxOpts?: CallOptions
+  ): Promise<SetTopicMetadataResponse>;
+  setMetadata(options: TopicMetadata, callback: SetTopicMetadataCallback): void;
+  setMetadata(
+    options: TopicMetadata,
+    gaxOpts: CallOptions,
+    callback: SetTopicMetadataCallback
+  ): void;
   /**
    * @typedef {array} SetTopicMetadataResponse
    * @property {object} 0 The full API response.
@@ -932,16 +942,6 @@ export class Topic {
    * });
    * ```
    */
-  setMetadata(
-    options: TopicMetadata,
-    gaxOpts?: CallOptions
-  ): Promise<SetTopicMetadataResponse>;
-  setMetadata(options: TopicMetadata, callback: SetTopicMetadataCallback): void;
-  setMetadata(
-    options: TopicMetadata,
-    gaxOpts: CallOptions,
-    callback: SetTopicMetadataCallback
-  ): void;
   setMetadata(
     options: TopicMetadata,
     optsOrCallback?: CallOptions | SetTopicMetadataCallback,

--- a/src/topic.ts
+++ b/src/topic.ts
@@ -182,8 +182,6 @@ export class Topic {
     this.iam = new IAM(pubsub, this.name);
   }
 
-  flush(): Promise<void>;
-  flush(callback: EmptyCallback): void;
   /**
    * Immediately sends all remaining queued data. This is mostly useful
    * if you are planning to call close() on the PubSub object that holds
@@ -192,15 +190,14 @@ export class Topic {
    * @param {EmptyCallback} [callback] Callback function.
    * @returns {Promise<EmptyResponse>}
    */
+  flush(): Promise<void>;
+  flush(callback: EmptyCallback): void;
   flush(callback?: EmptyCallback): Promise<void> | void {
     // It doesn't matter here if callback is undefined; the Publisher
     // flush() will handle it.
     this.publisher.flush(callback!);
   }
 
-  create(gaxOpts?: CallOptions): Promise<CreateTopicResponse>;
-  create(callback: CreateTopicCallback): void;
-  create(gaxOpts: CallOptions, callback: CreateTopicCallback): void;
   /**
    * Create a topic.
    *
@@ -231,6 +228,9 @@ export class Topic {
    * });
    * ```
    */
+  create(gaxOpts?: CallOptions): Promise<CreateTopicResponse>;
+  create(callback: CreateTopicCallback): void;
+  create(gaxOpts: CallOptions, callback: CreateTopicCallback): void;
   create(
     optsOrCallback?: CallOptions | CreateTopicCallback,
     callback?: CreateTopicCallback
@@ -241,16 +241,6 @@ export class Topic {
     this.pubsub.createTopic(this.name, gaxOpts, callback!);
   }
 
-  createSubscription(name: string, callback: CreateSubscriptionCallback): void;
-  createSubscription(
-    name: string,
-    options?: CreateSubscriptionOptions
-  ): Promise<CreateSubscriptionResponse>;
-  createSubscription(
-    name: string,
-    options: CreateSubscriptionOptions,
-    callback: CreateSubscriptionCallback
-  ): void;
   /**
    * Create a subscription to this topic.
    *
@@ -290,6 +280,16 @@ export class Topic {
    * });
    * ```
    */
+  createSubscription(name: string, callback: CreateSubscriptionCallback): void;
+  createSubscription(
+    name: string,
+    options?: CreateSubscriptionOptions
+  ): Promise<CreateSubscriptionResponse>;
+  createSubscription(
+    name: string,
+    options: CreateSubscriptionOptions,
+    callback: CreateSubscriptionCallback
+  ): void;
   createSubscription(
     name: string,
     optsOrCallback?: CreateSubscriptionOptions | CreateSubscriptionCallback,
@@ -306,9 +306,6 @@ export class Topic {
     );
   }
 
-  delete(callback: EmptyCallback): void;
-  delete(gaxOpts?: CallOptions): Promise<EmptyResponse>;
-  delete(gaxOpts: CallOptions, callback: EmptyCallback): void;
   /**
    * Delete the topic. This will not delete subscriptions to this topic.
    *
@@ -338,6 +335,9 @@ export class Topic {
    * });
    * ```
    */
+  delete(callback: EmptyCallback): void;
+  delete(gaxOpts?: CallOptions): Promise<EmptyResponse>;
+  delete(gaxOpts: CallOptions, callback: EmptyCallback): void;
   delete(
     optsOrCallback?: CallOptions | EmptyCallback,
     callback?: EmptyCallback
@@ -360,8 +360,6 @@ export class Topic {
     );
   }
 
-  exists(): Promise<ExistsResponse>;
-  exists(callback: ExistsCallback): void;
   /**
    * @typedef {array} TopicExistsResponse
    * @property {boolean} 0 Whether the topic exists
@@ -394,6 +392,8 @@ export class Topic {
    * });
    * ```
    */
+  exists(): Promise<ExistsResponse>;
+  exists(callback: ExistsCallback): void;
   exists(callback?: ExistsCallback): void | Promise<ExistsResponse> {
     this.getMetadata(err => {
       if (!err) {
@@ -408,9 +408,6 @@ export class Topic {
     });
   }
 
-  get(callback: GetTopicCallback): void;
-  get(gaxOpts?: GetTopicOptions): Promise<GetTopicResponse>;
-  get(gaxOpts: GetTopicOptions, callback: GetTopicCallback): void;
   /**
    * @typedef {array} GetTopicResponse
    * @property {Topic} 0 The {@link Topic}.
@@ -452,6 +449,9 @@ export class Topic {
    * });
    * ```
    */
+  get(callback: GetTopicCallback): void;
+  get(gaxOpts?: GetTopicOptions): Promise<GetTopicResponse>;
+  get(gaxOpts: GetTopicOptions, callback: GetTopicCallback): void;
   get(
     optsOrCallback?: GetTopicOptions | GetTopicCallback,
     callback?: GetTopicCallback
@@ -475,9 +475,6 @@ export class Topic {
     });
   }
 
-  getMetadata(callback: GetTopicMetadataCallback): void;
-  getMetadata(gaxOpts: CallOptions, callback: GetTopicMetadataCallback): void;
-  getMetadata(gaxOpts?: CallOptions): Promise<GetTopicMetadataResponse>;
   /**
    * @typedef {array} GetTopicMetadataResponse
    * @property {object} 0 The full API response.
@@ -514,6 +511,9 @@ export class Topic {
    * });
    * ```
    */
+  getMetadata(callback: GetTopicMetadataCallback): void;
+  getMetadata(gaxOpts: CallOptions, callback: GetTopicMetadataCallback): void;
+  getMetadata(gaxOpts?: CallOptions): Promise<GetTopicMetadataResponse>;
   getMetadata(
     optsOrCallback?: CallOptions | GetTopicMetadataCallback,
     callback?: GetTopicMetadataCallback
@@ -541,14 +541,6 @@ export class Topic {
     );
   }
 
-  getSubscriptions(callback: GetTopicSubscriptionsCallback): void;
-  getSubscriptions(
-    options: PageOptions,
-    callback: GetTopicSubscriptionsCallback
-  ): void;
-  getSubscriptions(
-    options?: PageOptions
-  ): Promise<GetTopicSubscriptionsResponse>;
   /**
    * Get a list of the subscriptions registered to this topic. You may
    * optionally provide a query object as the first argument to customize the
@@ -587,6 +579,14 @@ export class Topic {
    * });
    * ```
    */
+  getSubscriptions(callback: GetTopicSubscriptionsCallback): void;
+  getSubscriptions(
+    options: PageOptions,
+    callback: GetTopicSubscriptionsCallback
+  ): void;
+  getSubscriptions(
+    options?: PageOptions
+  ): Promise<GetTopicSubscriptionsResponse>;
   getSubscriptions(
     optsOrCallback?: PageOptions | GetTopicSubscriptionsCallback,
     callback?: GetTopicSubscriptionsCallback
@@ -631,13 +631,6 @@ export class Topic {
     );
   }
 
-  publish(data: Buffer, attributes?: Attributes): Promise<string>;
-  publish(data: Buffer, callback: PublishCallback): void;
-  publish(
-    data: Buffer,
-    attributes: Attributes,
-    callback: PublishCallback
-  ): void;
   /**
    * Publish the provided message.
    *
@@ -683,6 +676,13 @@ export class Topic {
    * topic.publish(data).then((messageId) => {});
    * ```
    */
+  publish(data: Buffer, attributes?: Attributes): Promise<string>;
+  publish(data: Buffer, callback: PublishCallback): void;
+  publish(
+    data: Buffer,
+    attributes: Attributes,
+    callback: PublishCallback
+  ): void;
   publish(
     data: Buffer,
     attrsOrCb?: Attributes | PublishCallback,
@@ -693,13 +693,6 @@ export class Topic {
     return this.publishMessage({data, attributes}, callback!);
   }
 
-  publishJSON(json: object, attributes?: Attributes): Promise<string>;
-  publishJSON(json: object, callback: PublishCallback): void;
-  publishJSON(
-    json: object,
-    attributes: Attributes,
-    callback: PublishCallback
-  ): void;
   /**
    * Publish the provided JSON. It should be noted that all messages published
    * are done so in the form of a Buffer. This is simply a convenience method
@@ -749,6 +742,13 @@ export class Topic {
    * topic.publishJSON(data).then((messageId) => {});
    * ```
    */
+  publishJSON(json: object, attributes?: Attributes): Promise<string>;
+  publishJSON(json: object, callback: PublishCallback): void;
+  publishJSON(
+    json: object,
+    attributes: Attributes,
+    callback: PublishCallback
+  ): void;
   publishJSON(
     json: object,
     attrsOrCb?: Attributes | PublishCallback,
@@ -763,8 +763,6 @@ export class Topic {
     return this.publishMessage({json, attributes}, callback!);
   }
 
-  publishMessage(message: MessageOptions): Promise<[string]>;
-  publishMessage(message: MessageOptions, callback: PublishCallback): void;
   /**
    * @typedef {object} MessageOptions
    * @property {buffer} [data] The message data.
@@ -824,6 +822,8 @@ export class Topic {
    * const [messageId] = await topic.publishMessage({data});
    * ```
    */
+  publishMessage(message: MessageOptions): Promise<[string]>;
+  publishMessage(message: MessageOptions, callback: PublishCallback): void;
   publishMessage(
     message: MessageOptions,
     callback?: PublishCallback
@@ -885,16 +885,6 @@ export class Topic {
     this.publisher.resumePublishing(orderingKey);
   }
 
-  setMetadata(
-    options: TopicMetadata,
-    gaxOpts?: CallOptions
-  ): Promise<SetTopicMetadataResponse>;
-  setMetadata(options: TopicMetadata, callback: SetTopicMetadataCallback): void;
-  setMetadata(
-    options: TopicMetadata,
-    gaxOpts: CallOptions,
-    callback: SetTopicMetadataCallback
-  ): void;
   /**
    * @typedef {array} SetTopicMetadataResponse
    * @property {object} 0 The full API response.
@@ -942,6 +932,16 @@ export class Topic {
    * });
    * ```
    */
+  setMetadata(
+    options: TopicMetadata,
+    gaxOpts?: CallOptions
+  ): Promise<SetTopicMetadataResponse>;
+  setMetadata(options: TopicMetadata, callback: SetTopicMetadataCallback): void;
+  setMetadata(
+    options: TopicMetadata,
+    gaxOpts: CallOptions,
+    callback: SetTopicMetadataCallback
+  ): void;
   setMetadata(
     options: TopicMetadata,
     optsOrCallback?: CallOptions | SetTopicMetadataCallback,

--- a/src/v1/publisher_client.ts
+++ b/src/v1/publisher_client.ts
@@ -352,12 +352,12 @@ export class PublisherClient {
     ];
   }
 
-  getProjectId(): Promise<string>;
-  getProjectId(callback: Callback<string, undefined, undefined>): void;
   /**
    * Return the project ID used by this class.
    * @returns {Promise} A promise that resolves to string containing the project ID.
    */
+  getProjectId(): Promise<string>;
+  getProjectId(callback: Callback<string, undefined, undefined>): void;
   getProjectId(
     callback?: Callback<string, undefined, undefined>
   ): Promise<string> | void {
@@ -371,33 +371,6 @@ export class PublisherClient {
   // -------------------
   // -- Service calls --
   // -------------------
-  createTopic(
-    request?: protos.google.pubsub.v1.ITopic,
-    options?: CallOptions
-  ): Promise<
-    [
-      protos.google.pubsub.v1.ITopic,
-      protos.google.pubsub.v1.ITopic | undefined,
-      {} | undefined
-    ]
-  >;
-  createTopic(
-    request: protos.google.pubsub.v1.ITopic,
-    options: CallOptions,
-    callback: Callback<
-      protos.google.pubsub.v1.ITopic,
-      protos.google.pubsub.v1.ITopic | null | undefined,
-      {} | null | undefined
-    >
-  ): void;
-  createTopic(
-    request: protos.google.pubsub.v1.ITopic,
-    callback: Callback<
-      protos.google.pubsub.v1.ITopic,
-      protos.google.pubsub.v1.ITopic | null | undefined,
-      {} | null | undefined
-    >
-  ): void;
   /**
    * Creates the given topic with the given name. See the [resource name rules]
    * (https://cloud.google.com/pubsub/docs/admin#resource_names).
@@ -451,6 +424,33 @@ export class PublisherClient {
    */
   createTopic(
     request?: protos.google.pubsub.v1.ITopic,
+    options?: CallOptions
+  ): Promise<
+    [
+      protos.google.pubsub.v1.ITopic,
+      protos.google.pubsub.v1.ITopic | undefined,
+      {} | undefined
+    ]
+  >;
+  createTopic(
+    request: protos.google.pubsub.v1.ITopic,
+    options: CallOptions,
+    callback: Callback<
+      protos.google.pubsub.v1.ITopic,
+      protos.google.pubsub.v1.ITopic | null | undefined,
+      {} | null | undefined
+    >
+  ): void;
+  createTopic(
+    request: protos.google.pubsub.v1.ITopic,
+    callback: Callback<
+      protos.google.pubsub.v1.ITopic,
+      protos.google.pubsub.v1.ITopic | null | undefined,
+      {} | null | undefined
+    >
+  ): void;
+  createTopic(
+    request?: protos.google.pubsub.v1.ITopic,
     optionsOrCallback?:
       | CallOptions
       | Callback<
@@ -488,6 +488,32 @@ export class PublisherClient {
     this.initialize();
     return this.innerApiCalls.createTopic(request, options, callback);
   }
+  /**
+   * Updates an existing topic. Note that certain properties of a
+   * topic are not modifiable.
+   *
+   * @param {Object} request
+   *   The request object that will be sent.
+   * @param {google.pubsub.v1.Topic} request.topic
+   *   Required. The updated topic object.
+   * @param {google.protobuf.FieldMask} request.updateMask
+   *   Required. Indicates which fields in the provided topic to update. Must be
+   *   specified and non-empty. Note that if `update_mask` contains
+   *   "message_storage_policy" but the `message_storage_policy` is not set in
+   *   the `topic` provided above, then the updated value is determined by the
+   *   policy configured at the project or organization level.
+   * @param {object} [options]
+   *   Call options. See {@link https://googleapis.dev/nodejs/google-gax/latest/interfaces/CallOptions.html|CallOptions} for more details.
+   * @returns {Promise} - The promise which resolves to an array.
+   *   The first element of the array is an object representing [Topic]{@link google.pubsub.v1.Topic}.
+   *   Please see the
+   *   [documentation](https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#regular-methods)
+   *   for more details and examples.
+   * @example
+   * ```
+   * const [response] = await client.updateTopic(request);
+   * ```
+   */
   updateTopic(
     request?: protos.google.pubsub.v1.IUpdateTopicRequest,
     options?: CallOptions
@@ -515,32 +541,6 @@ export class PublisherClient {
       {} | null | undefined
     >
   ): void;
-  /**
-   * Updates an existing topic. Note that certain properties of a
-   * topic are not modifiable.
-   *
-   * @param {Object} request
-   *   The request object that will be sent.
-   * @param {google.pubsub.v1.Topic} request.topic
-   *   Required. The updated topic object.
-   * @param {google.protobuf.FieldMask} request.updateMask
-   *   Required. Indicates which fields in the provided topic to update. Must be
-   *   specified and non-empty. Note that if `update_mask` contains
-   *   "message_storage_policy" but the `message_storage_policy` is not set in
-   *   the `topic` provided above, then the updated value is determined by the
-   *   policy configured at the project or organization level.
-   * @param {object} [options]
-   *   Call options. See {@link https://googleapis.dev/nodejs/google-gax/latest/interfaces/CallOptions.html|CallOptions} for more details.
-   * @returns {Promise} - The promise which resolves to an array.
-   *   The first element of the array is an object representing [Topic]{@link google.pubsub.v1.Topic}.
-   *   Please see the
-   *   [documentation](https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#regular-methods)
-   *   for more details and examples.
-   * @example
-   * ```
-   * const [response] = await client.updateTopic(request);
-   * ```
-   */
   updateTopic(
     request?: protos.google.pubsub.v1.IUpdateTopicRequest,
     optionsOrCallback?:
@@ -580,6 +580,29 @@ export class PublisherClient {
     this.initialize();
     return this.innerApiCalls.updateTopic(request, options, callback);
   }
+  /**
+   * Adds one or more messages to the topic. Returns `NOT_FOUND` if the topic
+   * does not exist.
+   *
+   * @param {Object} request
+   *   The request object that will be sent.
+   * @param {string} request.topic
+   *   Required. The messages in the request will be published on this topic.
+   *   Format is `projects/{project}/topics/{topic}`.
+   * @param {number[]} request.messages
+   *   Required. The messages to publish.
+   * @param {object} [options]
+   *   Call options. See {@link https://googleapis.dev/nodejs/google-gax/latest/interfaces/CallOptions.html|CallOptions} for more details.
+   * @returns {Promise} - The promise which resolves to an array.
+   *   The first element of the array is an object representing [PublishResponse]{@link google.pubsub.v1.PublishResponse}.
+   *   Please see the
+   *   [documentation](https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#regular-methods)
+   *   for more details and examples.
+   * @example
+   * ```
+   * const [response] = await client.publish(request);
+   * ```
+   */
   publish(
     request?: protos.google.pubsub.v1.IPublishRequest,
     options?: CallOptions
@@ -607,29 +630,6 @@ export class PublisherClient {
       {} | null | undefined
     >
   ): void;
-  /**
-   * Adds one or more messages to the topic. Returns `NOT_FOUND` if the topic
-   * does not exist.
-   *
-   * @param {Object} request
-   *   The request object that will be sent.
-   * @param {string} request.topic
-   *   Required. The messages in the request will be published on this topic.
-   *   Format is `projects/{project}/topics/{topic}`.
-   * @param {number[]} request.messages
-   *   Required. The messages to publish.
-   * @param {object} [options]
-   *   Call options. See {@link https://googleapis.dev/nodejs/google-gax/latest/interfaces/CallOptions.html|CallOptions} for more details.
-   * @returns {Promise} - The promise which resolves to an array.
-   *   The first element of the array is an object representing [PublishResponse]{@link google.pubsub.v1.PublishResponse}.
-   *   Please see the
-   *   [documentation](https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#regular-methods)
-   *   for more details and examples.
-   * @example
-   * ```
-   * const [response] = await client.publish(request);
-   * ```
-   */
   publish(
     request?: protos.google.pubsub.v1.IPublishRequest,
     optionsOrCallback?:
@@ -669,6 +669,26 @@ export class PublisherClient {
     this.initialize();
     return this.innerApiCalls.publish(request, options, callback);
   }
+  /**
+   * Gets the configuration of a topic.
+   *
+   * @param {Object} request
+   *   The request object that will be sent.
+   * @param {string} request.topic
+   *   Required. The name of the topic to get.
+   *   Format is `projects/{project}/topics/{topic}`.
+   * @param {object} [options]
+   *   Call options. See {@link https://googleapis.dev/nodejs/google-gax/latest/interfaces/CallOptions.html|CallOptions} for more details.
+   * @returns {Promise} - The promise which resolves to an array.
+   *   The first element of the array is an object representing [Topic]{@link google.pubsub.v1.Topic}.
+   *   Please see the
+   *   [documentation](https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#regular-methods)
+   *   for more details and examples.
+   * @example
+   * ```
+   * const [response] = await client.getTopic(request);
+   * ```
+   */
   getTopic(
     request?: protos.google.pubsub.v1.IGetTopicRequest,
     options?: CallOptions
@@ -696,26 +716,6 @@ export class PublisherClient {
       {} | null | undefined
     >
   ): void;
-  /**
-   * Gets the configuration of a topic.
-   *
-   * @param {Object} request
-   *   The request object that will be sent.
-   * @param {string} request.topic
-   *   Required. The name of the topic to get.
-   *   Format is `projects/{project}/topics/{topic}`.
-   * @param {object} [options]
-   *   Call options. See {@link https://googleapis.dev/nodejs/google-gax/latest/interfaces/CallOptions.html|CallOptions} for more details.
-   * @returns {Promise} - The promise which resolves to an array.
-   *   The first element of the array is an object representing [Topic]{@link google.pubsub.v1.Topic}.
-   *   Please see the
-   *   [documentation](https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#regular-methods)
-   *   for more details and examples.
-   * @example
-   * ```
-   * const [response] = await client.getTopic(request);
-   * ```
-   */
   getTopic(
     request?: protos.google.pubsub.v1.IGetTopicRequest,
     optionsOrCallback?:
@@ -755,6 +755,30 @@ export class PublisherClient {
     this.initialize();
     return this.innerApiCalls.getTopic(request, options, callback);
   }
+  /**
+   * Deletes the topic with the given name. Returns `NOT_FOUND` if the topic
+   * does not exist. After a topic is deleted, a new topic may be created with
+   * the same name; this is an entirely new topic with none of the old
+   * configuration or subscriptions. Existing subscriptions to this topic are
+   * not deleted, but their `topic` field is set to `_deleted-topic_`.
+   *
+   * @param {Object} request
+   *   The request object that will be sent.
+   * @param {string} request.topic
+   *   Required. Name of the topic to delete.
+   *   Format is `projects/{project}/topics/{topic}`.
+   * @param {object} [options]
+   *   Call options. See {@link https://googleapis.dev/nodejs/google-gax/latest/interfaces/CallOptions.html|CallOptions} for more details.
+   * @returns {Promise} - The promise which resolves to an array.
+   *   The first element of the array is an object representing [Empty]{@link google.protobuf.Empty}.
+   *   Please see the
+   *   [documentation](https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#regular-methods)
+   *   for more details and examples.
+   * @example
+   * ```
+   * const [response] = await client.deleteTopic(request);
+   * ```
+   */
   deleteTopic(
     request?: protos.google.pubsub.v1.IDeleteTopicRequest,
     options?: CallOptions
@@ -782,30 +806,6 @@ export class PublisherClient {
       {} | null | undefined
     >
   ): void;
-  /**
-   * Deletes the topic with the given name. Returns `NOT_FOUND` if the topic
-   * does not exist. After a topic is deleted, a new topic may be created with
-   * the same name; this is an entirely new topic with none of the old
-   * configuration or subscriptions. Existing subscriptions to this topic are
-   * not deleted, but their `topic` field is set to `_deleted-topic_`.
-   *
-   * @param {Object} request
-   *   The request object that will be sent.
-   * @param {string} request.topic
-   *   Required. Name of the topic to delete.
-   *   Format is `projects/{project}/topics/{topic}`.
-   * @param {object} [options]
-   *   Call options. See {@link https://googleapis.dev/nodejs/google-gax/latest/interfaces/CallOptions.html|CallOptions} for more details.
-   * @returns {Promise} - The promise which resolves to an array.
-   *   The first element of the array is an object representing [Empty]{@link google.protobuf.Empty}.
-   *   Please see the
-   *   [documentation](https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#regular-methods)
-   *   for more details and examples.
-   * @example
-   * ```
-   * const [response] = await client.deleteTopic(request);
-   * ```
-   */
   deleteTopic(
     request?: protos.google.pubsub.v1.IDeleteTopicRequest,
     optionsOrCallback?:
@@ -845,6 +845,29 @@ export class PublisherClient {
     this.initialize();
     return this.innerApiCalls.deleteTopic(request, options, callback);
   }
+  /**
+   * Detaches a subscription from this topic. All messages retained in the
+   * subscription are dropped. Subsequent `Pull` and `StreamingPull` requests
+   * will return FAILED_PRECONDITION. If the subscription is a push
+   * subscription, pushes to the endpoint will stop.
+   *
+   * @param {Object} request
+   *   The request object that will be sent.
+   * @param {string} request.subscription
+   *   Required. The subscription to detach.
+   *   Format is `projects/{project}/subscriptions/{subscription}`.
+   * @param {object} [options]
+   *   Call options. See {@link https://googleapis.dev/nodejs/google-gax/latest/interfaces/CallOptions.html|CallOptions} for more details.
+   * @returns {Promise} - The promise which resolves to an array.
+   *   The first element of the array is an object representing [DetachSubscriptionResponse]{@link google.pubsub.v1.DetachSubscriptionResponse}.
+   *   Please see the
+   *   [documentation](https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#regular-methods)
+   *   for more details and examples.
+   * @example
+   * ```
+   * const [response] = await client.detachSubscription(request);
+   * ```
+   */
   detachSubscription(
     request?: protos.google.pubsub.v1.IDetachSubscriptionRequest,
     options?: CallOptions
@@ -872,29 +895,6 @@ export class PublisherClient {
       {} | null | undefined
     >
   ): void;
-  /**
-   * Detaches a subscription from this topic. All messages retained in the
-   * subscription are dropped. Subsequent `Pull` and `StreamingPull` requests
-   * will return FAILED_PRECONDITION. If the subscription is a push
-   * subscription, pushes to the endpoint will stop.
-   *
-   * @param {Object} request
-   *   The request object that will be sent.
-   * @param {string} request.subscription
-   *   Required. The subscription to detach.
-   *   Format is `projects/{project}/subscriptions/{subscription}`.
-   * @param {object} [options]
-   *   Call options. See {@link https://googleapis.dev/nodejs/google-gax/latest/interfaces/CallOptions.html|CallOptions} for more details.
-   * @returns {Promise} - The promise which resolves to an array.
-   *   The first element of the array is an object representing [DetachSubscriptionResponse]{@link google.pubsub.v1.DetachSubscriptionResponse}.
-   *   Please see the
-   *   [documentation](https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#regular-methods)
-   *   for more details and examples.
-   * @example
-   * ```
-   * const [response] = await client.detachSubscription(request);
-   * ```
-   */
   detachSubscription(
     request?: protos.google.pubsub.v1.IDetachSubscriptionRequest,
     optionsOrCallback?:
@@ -935,33 +935,6 @@ export class PublisherClient {
     return this.innerApiCalls.detachSubscription(request, options, callback);
   }
 
-  listTopics(
-    request?: protos.google.pubsub.v1.IListTopicsRequest,
-    options?: CallOptions
-  ): Promise<
-    [
-      protos.google.pubsub.v1.ITopic[],
-      protos.google.pubsub.v1.IListTopicsRequest | null,
-      protos.google.pubsub.v1.IListTopicsResponse
-    ]
-  >;
-  listTopics(
-    request: protos.google.pubsub.v1.IListTopicsRequest,
-    options: CallOptions,
-    callback: PaginationCallback<
-      protos.google.pubsub.v1.IListTopicsRequest,
-      protos.google.pubsub.v1.IListTopicsResponse | null | undefined,
-      protos.google.pubsub.v1.ITopic
-    >
-  ): void;
-  listTopics(
-    request: protos.google.pubsub.v1.IListTopicsRequest,
-    callback: PaginationCallback<
-      protos.google.pubsub.v1.IListTopicsRequest,
-      protos.google.pubsub.v1.IListTopicsResponse | null | undefined,
-      protos.google.pubsub.v1.ITopic
-    >
-  ): void;
   /**
    * Lists matching topics.
    *
@@ -989,6 +962,33 @@ export class PublisherClient {
    *   [documentation](https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#auto-pagination)
    *   for more details and examples.
    */
+  listTopics(
+    request?: protos.google.pubsub.v1.IListTopicsRequest,
+    options?: CallOptions
+  ): Promise<
+    [
+      protos.google.pubsub.v1.ITopic[],
+      protos.google.pubsub.v1.IListTopicsRequest | null,
+      protos.google.pubsub.v1.IListTopicsResponse
+    ]
+  >;
+  listTopics(
+    request: protos.google.pubsub.v1.IListTopicsRequest,
+    options: CallOptions,
+    callback: PaginationCallback<
+      protos.google.pubsub.v1.IListTopicsRequest,
+      protos.google.pubsub.v1.IListTopicsResponse | null | undefined,
+      protos.google.pubsub.v1.ITopic
+    >
+  ): void;
+  listTopics(
+    request: protos.google.pubsub.v1.IListTopicsRequest,
+    callback: PaginationCallback<
+      protos.google.pubsub.v1.IListTopicsRequest,
+      protos.google.pubsub.v1.IListTopicsResponse | null | undefined,
+      protos.google.pubsub.v1.ITopic
+    >
+  ): void;
   listTopics(
     request?: protos.google.pubsub.v1.IListTopicsRequest,
     optionsOrCallback?:
@@ -1129,6 +1129,33 @@ export class PublisherClient {
       callSettings
     ) as AsyncIterable<protos.google.pubsub.v1.ITopic>;
   }
+  /**
+   * Lists the names of the attached subscriptions on this topic.
+   *
+   * @param {Object} request
+   *   The request object that will be sent.
+   * @param {string} request.topic
+   *   Required. The name of the topic that subscriptions are attached to.
+   *   Format is `projects/{project}/topics/{topic}`.
+   * @param {number} request.pageSize
+   *   Maximum number of subscription names to return.
+   * @param {string} request.pageToken
+   *   The value returned by the last `ListTopicSubscriptionsResponse`; indicates
+   *   that this is a continuation of a prior `ListTopicSubscriptions` call, and
+   *   that the system should return the next page of data.
+   * @param {object} [options]
+   *   Call options. See {@link https://googleapis.dev/nodejs/google-gax/latest/interfaces/CallOptions.html|CallOptions} for more details.
+   * @returns {Promise} - The promise which resolves to an array.
+   *   The first element of the array is Array of string.
+   *   The client library will perform auto-pagination by default: it will call the API as many
+   *   times as needed and will merge results from all the pages into this array.
+   *   Note that it can affect your quota.
+   *   We recommend using `listTopicSubscriptionsAsync()`
+   *   method described below for async iteration which you can stop as needed.
+   *   Please see the
+   *   [documentation](https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#auto-pagination)
+   *   for more details and examples.
+   */
   listTopicSubscriptions(
     request?: protos.google.pubsub.v1.IListTopicSubscriptionsRequest,
     options?: CallOptions
@@ -1160,33 +1187,6 @@ export class PublisherClient {
       string
     >
   ): void;
-  /**
-   * Lists the names of the attached subscriptions on this topic.
-   *
-   * @param {Object} request
-   *   The request object that will be sent.
-   * @param {string} request.topic
-   *   Required. The name of the topic that subscriptions are attached to.
-   *   Format is `projects/{project}/topics/{topic}`.
-   * @param {number} request.pageSize
-   *   Maximum number of subscription names to return.
-   * @param {string} request.pageToken
-   *   The value returned by the last `ListTopicSubscriptionsResponse`; indicates
-   *   that this is a continuation of a prior `ListTopicSubscriptions` call, and
-   *   that the system should return the next page of data.
-   * @param {object} [options]
-   *   Call options. See {@link https://googleapis.dev/nodejs/google-gax/latest/interfaces/CallOptions.html|CallOptions} for more details.
-   * @returns {Promise} - The promise which resolves to an array.
-   *   The first element of the array is Array of string.
-   *   The client library will perform auto-pagination by default: it will call the API as many
-   *   times as needed and will merge results from all the pages into this array.
-   *   Note that it can affect your quota.
-   *   We recommend using `listTopicSubscriptionsAsync()`
-   *   method described below for async iteration which you can stop as needed.
-   *   Please see the
-   *   [documentation](https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#auto-pagination)
-   *   for more details and examples.
-   */
   listTopicSubscriptions(
     request?: protos.google.pubsub.v1.IListTopicSubscriptionsRequest,
     optionsOrCallback?:
@@ -1335,33 +1335,6 @@ export class PublisherClient {
       callSettings
     ) as AsyncIterable<string>;
   }
-  listTopicSnapshots(
-    request?: protos.google.pubsub.v1.IListTopicSnapshotsRequest,
-    options?: CallOptions
-  ): Promise<
-    [
-      string[],
-      protos.google.pubsub.v1.IListTopicSnapshotsRequest | null,
-      protos.google.pubsub.v1.IListTopicSnapshotsResponse
-    ]
-  >;
-  listTopicSnapshots(
-    request: protos.google.pubsub.v1.IListTopicSnapshotsRequest,
-    options: CallOptions,
-    callback: PaginationCallback<
-      protos.google.pubsub.v1.IListTopicSnapshotsRequest,
-      protos.google.pubsub.v1.IListTopicSnapshotsResponse | null | undefined,
-      string
-    >
-  ): void;
-  listTopicSnapshots(
-    request: protos.google.pubsub.v1.IListTopicSnapshotsRequest,
-    callback: PaginationCallback<
-      protos.google.pubsub.v1.IListTopicSnapshotsRequest,
-      protos.google.pubsub.v1.IListTopicSnapshotsResponse | null | undefined,
-      string
-    >
-  ): void;
   /**
    * Lists the names of the snapshots on this topic. Snapshots are used in
    * [Seek](https://cloud.google.com/pubsub/docs/replay-overview) operations,
@@ -1393,6 +1366,33 @@ export class PublisherClient {
    *   [documentation](https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#auto-pagination)
    *   for more details and examples.
    */
+  listTopicSnapshots(
+    request?: protos.google.pubsub.v1.IListTopicSnapshotsRequest,
+    options?: CallOptions
+  ): Promise<
+    [
+      string[],
+      protos.google.pubsub.v1.IListTopicSnapshotsRequest | null,
+      protos.google.pubsub.v1.IListTopicSnapshotsResponse
+    ]
+  >;
+  listTopicSnapshots(
+    request: protos.google.pubsub.v1.IListTopicSnapshotsRequest,
+    options: CallOptions,
+    callback: PaginationCallback<
+      protos.google.pubsub.v1.IListTopicSnapshotsRequest,
+      protos.google.pubsub.v1.IListTopicSnapshotsResponse | null | undefined,
+      string
+    >
+  ): void;
+  listTopicSnapshots(
+    request: protos.google.pubsub.v1.IListTopicSnapshotsRequest,
+    callback: PaginationCallback<
+      protos.google.pubsub.v1.IListTopicSnapshotsRequest,
+      protos.google.pubsub.v1.IListTopicSnapshotsResponse | null | undefined,
+      string
+    >
+  ): void;
   listTopicSnapshots(
     request?: protos.google.pubsub.v1.IListTopicSnapshotsRequest,
     optionsOrCallback?:

--- a/src/v1/schema_service_client.ts
+++ b/src/v1/schema_service_client.ts
@@ -318,12 +318,12 @@ export class SchemaServiceClient {
     ];
   }
 
-  getProjectId(): Promise<string>;
-  getProjectId(callback: Callback<string, undefined, undefined>): void;
   /**
    * Return the project ID used by this class.
    * @returns {Promise} A promise that resolves to string containing the project ID.
    */
+  getProjectId(): Promise<string>;
+  getProjectId(callback: Callback<string, undefined, undefined>): void;
   getProjectId(
     callback?: Callback<string, undefined, undefined>
   ): Promise<string> | void {
@@ -337,33 +337,6 @@ export class SchemaServiceClient {
   // -------------------
   // -- Service calls --
   // -------------------
-  createSchema(
-    request?: protos.google.pubsub.v1.ICreateSchemaRequest,
-    options?: CallOptions
-  ): Promise<
-    [
-      protos.google.pubsub.v1.ISchema,
-      protos.google.pubsub.v1.ICreateSchemaRequest | undefined,
-      {} | undefined
-    ]
-  >;
-  createSchema(
-    request: protos.google.pubsub.v1.ICreateSchemaRequest,
-    options: CallOptions,
-    callback: Callback<
-      protos.google.pubsub.v1.ISchema,
-      protos.google.pubsub.v1.ICreateSchemaRequest | null | undefined,
-      {} | null | undefined
-    >
-  ): void;
-  createSchema(
-    request: protos.google.pubsub.v1.ICreateSchemaRequest,
-    callback: Callback<
-      protos.google.pubsub.v1.ISchema,
-      protos.google.pubsub.v1.ICreateSchemaRequest | null | undefined,
-      {} | null | undefined
-    >
-  ): void;
   /**
    * Creates a schema.
    *
@@ -396,6 +369,33 @@ export class SchemaServiceClient {
    * const [response] = await client.createSchema(request);
    * ```
    */
+  createSchema(
+    request?: protos.google.pubsub.v1.ICreateSchemaRequest,
+    options?: CallOptions
+  ): Promise<
+    [
+      protos.google.pubsub.v1.ISchema,
+      protos.google.pubsub.v1.ICreateSchemaRequest | undefined,
+      {} | undefined
+    ]
+  >;
+  createSchema(
+    request: protos.google.pubsub.v1.ICreateSchemaRequest,
+    options: CallOptions,
+    callback: Callback<
+      protos.google.pubsub.v1.ISchema,
+      protos.google.pubsub.v1.ICreateSchemaRequest | null | undefined,
+      {} | null | undefined
+    >
+  ): void;
+  createSchema(
+    request: protos.google.pubsub.v1.ICreateSchemaRequest,
+    callback: Callback<
+      protos.google.pubsub.v1.ISchema,
+      protos.google.pubsub.v1.ICreateSchemaRequest | null | undefined,
+      {} | null | undefined
+    >
+  ): void;
   createSchema(
     request?: protos.google.pubsub.v1.ICreateSchemaRequest,
     optionsOrCallback?:
@@ -435,6 +435,30 @@ export class SchemaServiceClient {
     this.initialize();
     return this.innerApiCalls.createSchema(request, options, callback);
   }
+  /**
+   * Gets a schema.
+   *
+   * @param {Object} request
+   *   The request object that will be sent.
+   * @param {string} request.name
+   *   Required. The name of the schema to get.
+   *   Format is `projects/{project}/schemas/{schema}`.
+   * @param {google.pubsub.v1.SchemaView} request.view
+   *   The set of fields to return in the response. If not set, returns a Schema
+   *   with `name` and `type`, but not `definition`. Set to `FULL` to retrieve all
+   *   fields.
+   * @param {object} [options]
+   *   Call options. See {@link https://googleapis.dev/nodejs/google-gax/latest/interfaces/CallOptions.html|CallOptions} for more details.
+   * @returns {Promise} - The promise which resolves to an array.
+   *   The first element of the array is an object representing [Schema]{@link google.pubsub.v1.Schema}.
+   *   Please see the
+   *   [documentation](https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#regular-methods)
+   *   for more details and examples.
+   * @example
+   * ```
+   * const [response] = await client.getSchema(request);
+   * ```
+   */
   getSchema(
     request?: protos.google.pubsub.v1.IGetSchemaRequest,
     options?: CallOptions
@@ -462,30 +486,6 @@ export class SchemaServiceClient {
       {} | null | undefined
     >
   ): void;
-  /**
-   * Gets a schema.
-   *
-   * @param {Object} request
-   *   The request object that will be sent.
-   * @param {string} request.name
-   *   Required. The name of the schema to get.
-   *   Format is `projects/{project}/schemas/{schema}`.
-   * @param {google.pubsub.v1.SchemaView} request.view
-   *   The set of fields to return in the response. If not set, returns a Schema
-   *   with `name` and `type`, but not `definition`. Set to `FULL` to retrieve all
-   *   fields.
-   * @param {object} [options]
-   *   Call options. See {@link https://googleapis.dev/nodejs/google-gax/latest/interfaces/CallOptions.html|CallOptions} for more details.
-   * @returns {Promise} - The promise which resolves to an array.
-   *   The first element of the array is an object representing [Schema]{@link google.pubsub.v1.Schema}.
-   *   Please see the
-   *   [documentation](https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#regular-methods)
-   *   for more details and examples.
-   * @example
-   * ```
-   * const [response] = await client.getSchema(request);
-   * ```
-   */
   getSchema(
     request?: protos.google.pubsub.v1.IGetSchemaRequest,
     optionsOrCallback?:
@@ -525,6 +525,26 @@ export class SchemaServiceClient {
     this.initialize();
     return this.innerApiCalls.getSchema(request, options, callback);
   }
+  /**
+   * Deletes a schema.
+   *
+   * @param {Object} request
+   *   The request object that will be sent.
+   * @param {string} request.name
+   *   Required. Name of the schema to delete.
+   *   Format is `projects/{project}/schemas/{schema}`.
+   * @param {object} [options]
+   *   Call options. See {@link https://googleapis.dev/nodejs/google-gax/latest/interfaces/CallOptions.html|CallOptions} for more details.
+   * @returns {Promise} - The promise which resolves to an array.
+   *   The first element of the array is an object representing [Empty]{@link google.protobuf.Empty}.
+   *   Please see the
+   *   [documentation](https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#regular-methods)
+   *   for more details and examples.
+   * @example
+   * ```
+   * const [response] = await client.deleteSchema(request);
+   * ```
+   */
   deleteSchema(
     request?: protos.google.pubsub.v1.IDeleteSchemaRequest,
     options?: CallOptions
@@ -552,26 +572,6 @@ export class SchemaServiceClient {
       {} | null | undefined
     >
   ): void;
-  /**
-   * Deletes a schema.
-   *
-   * @param {Object} request
-   *   The request object that will be sent.
-   * @param {string} request.name
-   *   Required. Name of the schema to delete.
-   *   Format is `projects/{project}/schemas/{schema}`.
-   * @param {object} [options]
-   *   Call options. See {@link https://googleapis.dev/nodejs/google-gax/latest/interfaces/CallOptions.html|CallOptions} for more details.
-   * @returns {Promise} - The promise which resolves to an array.
-   *   The first element of the array is an object representing [Empty]{@link google.protobuf.Empty}.
-   *   Please see the
-   *   [documentation](https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#regular-methods)
-   *   for more details and examples.
-   * @example
-   * ```
-   * const [response] = await client.deleteSchema(request);
-   * ```
-   */
   deleteSchema(
     request?: protos.google.pubsub.v1.IDeleteSchemaRequest,
     optionsOrCallback?:
@@ -611,6 +611,28 @@ export class SchemaServiceClient {
     this.initialize();
     return this.innerApiCalls.deleteSchema(request, options, callback);
   }
+  /**
+   * Validates a schema.
+   *
+   * @param {Object} request
+   *   The request object that will be sent.
+   * @param {string} request.parent
+   *   Required. The name of the project in which to validate schemas.
+   *   Format is `projects/{project-id}`.
+   * @param {google.pubsub.v1.Schema} request.schema
+   *   Required. The schema object to validate.
+   * @param {object} [options]
+   *   Call options. See {@link https://googleapis.dev/nodejs/google-gax/latest/interfaces/CallOptions.html|CallOptions} for more details.
+   * @returns {Promise} - The promise which resolves to an array.
+   *   The first element of the array is an object representing [ValidateSchemaResponse]{@link google.pubsub.v1.ValidateSchemaResponse}.
+   *   Please see the
+   *   [documentation](https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#regular-methods)
+   *   for more details and examples.
+   * @example
+   * ```
+   * const [response] = await client.validateSchema(request);
+   * ```
+   */
   validateSchema(
     request?: protos.google.pubsub.v1.IValidateSchemaRequest,
     options?: CallOptions
@@ -638,28 +660,6 @@ export class SchemaServiceClient {
       {} | null | undefined
     >
   ): void;
-  /**
-   * Validates a schema.
-   *
-   * @param {Object} request
-   *   The request object that will be sent.
-   * @param {string} request.parent
-   *   Required. The name of the project in which to validate schemas.
-   *   Format is `projects/{project-id}`.
-   * @param {google.pubsub.v1.Schema} request.schema
-   *   Required. The schema object to validate.
-   * @param {object} [options]
-   *   Call options. See {@link https://googleapis.dev/nodejs/google-gax/latest/interfaces/CallOptions.html|CallOptions} for more details.
-   * @returns {Promise} - The promise which resolves to an array.
-   *   The first element of the array is an object representing [ValidateSchemaResponse]{@link google.pubsub.v1.ValidateSchemaResponse}.
-   *   Please see the
-   *   [documentation](https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#regular-methods)
-   *   for more details and examples.
-   * @example
-   * ```
-   * const [response] = await client.validateSchema(request);
-   * ```
-   */
   validateSchema(
     request?: protos.google.pubsub.v1.IValidateSchemaRequest,
     optionsOrCallback?:
@@ -699,33 +699,6 @@ export class SchemaServiceClient {
     this.initialize();
     return this.innerApiCalls.validateSchema(request, options, callback);
   }
-  validateMessage(
-    request?: protos.google.pubsub.v1.IValidateMessageRequest,
-    options?: CallOptions
-  ): Promise<
-    [
-      protos.google.pubsub.v1.IValidateMessageResponse,
-      protos.google.pubsub.v1.IValidateMessageRequest | undefined,
-      {} | undefined
-    ]
-  >;
-  validateMessage(
-    request: protos.google.pubsub.v1.IValidateMessageRequest,
-    options: CallOptions,
-    callback: Callback<
-      protos.google.pubsub.v1.IValidateMessageResponse,
-      protos.google.pubsub.v1.IValidateMessageRequest | null | undefined,
-      {} | null | undefined
-    >
-  ): void;
-  validateMessage(
-    request: protos.google.pubsub.v1.IValidateMessageRequest,
-    callback: Callback<
-      protos.google.pubsub.v1.IValidateMessageResponse,
-      protos.google.pubsub.v1.IValidateMessageRequest | null | undefined,
-      {} | null | undefined
-    >
-  ): void;
   /**
    * Validates a message against a schema.
    *
@@ -756,6 +729,33 @@ export class SchemaServiceClient {
    * const [response] = await client.validateMessage(request);
    * ```
    */
+  validateMessage(
+    request?: protos.google.pubsub.v1.IValidateMessageRequest,
+    options?: CallOptions
+  ): Promise<
+    [
+      protos.google.pubsub.v1.IValidateMessageResponse,
+      protos.google.pubsub.v1.IValidateMessageRequest | undefined,
+      {} | undefined
+    ]
+  >;
+  validateMessage(
+    request: protos.google.pubsub.v1.IValidateMessageRequest,
+    options: CallOptions,
+    callback: Callback<
+      protos.google.pubsub.v1.IValidateMessageResponse,
+      protos.google.pubsub.v1.IValidateMessageRequest | null | undefined,
+      {} | null | undefined
+    >
+  ): void;
+  validateMessage(
+    request: protos.google.pubsub.v1.IValidateMessageRequest,
+    callback: Callback<
+      protos.google.pubsub.v1.IValidateMessageResponse,
+      protos.google.pubsub.v1.IValidateMessageRequest | null | undefined,
+      {} | null | undefined
+    >
+  ): void;
   validateMessage(
     request?: protos.google.pubsub.v1.IValidateMessageRequest,
     optionsOrCallback?:
@@ -796,33 +796,6 @@ export class SchemaServiceClient {
     return this.innerApiCalls.validateMessage(request, options, callback);
   }
 
-  listSchemas(
-    request?: protos.google.pubsub.v1.IListSchemasRequest,
-    options?: CallOptions
-  ): Promise<
-    [
-      protos.google.pubsub.v1.ISchema[],
-      protos.google.pubsub.v1.IListSchemasRequest | null,
-      protos.google.pubsub.v1.IListSchemasResponse
-    ]
-  >;
-  listSchemas(
-    request: protos.google.pubsub.v1.IListSchemasRequest,
-    options: CallOptions,
-    callback: PaginationCallback<
-      protos.google.pubsub.v1.IListSchemasRequest,
-      protos.google.pubsub.v1.IListSchemasResponse | null | undefined,
-      protos.google.pubsub.v1.ISchema
-    >
-  ): void;
-  listSchemas(
-    request: protos.google.pubsub.v1.IListSchemasRequest,
-    callback: PaginationCallback<
-      protos.google.pubsub.v1.IListSchemasRequest,
-      protos.google.pubsub.v1.IListSchemasResponse | null | undefined,
-      protos.google.pubsub.v1.ISchema
-    >
-  ): void;
   /**
    * Lists schemas in a project.
    *
@@ -854,6 +827,33 @@ export class SchemaServiceClient {
    *   [documentation](https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#auto-pagination)
    *   for more details and examples.
    */
+  listSchemas(
+    request?: protos.google.pubsub.v1.IListSchemasRequest,
+    options?: CallOptions
+  ): Promise<
+    [
+      protos.google.pubsub.v1.ISchema[],
+      protos.google.pubsub.v1.IListSchemasRequest | null,
+      protos.google.pubsub.v1.IListSchemasResponse
+    ]
+  >;
+  listSchemas(
+    request: protos.google.pubsub.v1.IListSchemasRequest,
+    options: CallOptions,
+    callback: PaginationCallback<
+      protos.google.pubsub.v1.IListSchemasRequest,
+      protos.google.pubsub.v1.IListSchemasResponse | null | undefined,
+      protos.google.pubsub.v1.ISchema
+    >
+  ): void;
+  listSchemas(
+    request: protos.google.pubsub.v1.IListSchemasRequest,
+    callback: PaginationCallback<
+      protos.google.pubsub.v1.IListSchemasRequest,
+      protos.google.pubsub.v1.IListSchemasResponse | null | undefined,
+      protos.google.pubsub.v1.ISchema
+    >
+  ): void;
   listSchemas(
     request?: protos.google.pubsub.v1.IListSchemasRequest,
     optionsOrCallback?:

--- a/src/v1/subscriber_client.ts
+++ b/src/v1/subscriber_client.ts
@@ -346,12 +346,12 @@ export class SubscriberClient {
     ];
   }
 
-  getProjectId(): Promise<string>;
-  getProjectId(callback: Callback<string, undefined, undefined>): void;
   /**
    * Return the project ID used by this class.
    * @returns {Promise} A promise that resolves to string containing the project ID.
    */
+  getProjectId(): Promise<string>;
+  getProjectId(callback: Callback<string, undefined, undefined>): void;
   getProjectId(
     callback?: Callback<string, undefined, undefined>
   ): Promise<string> | void {
@@ -365,33 +365,6 @@ export class SubscriberClient {
   // -------------------
   // -- Service calls --
   // -------------------
-  createSubscription(
-    request?: protos.google.pubsub.v1.ISubscription,
-    options?: CallOptions
-  ): Promise<
-    [
-      protos.google.pubsub.v1.ISubscription,
-      protos.google.pubsub.v1.ISubscription | undefined,
-      {} | undefined
-    ]
-  >;
-  createSubscription(
-    request: protos.google.pubsub.v1.ISubscription,
-    options: CallOptions,
-    callback: Callback<
-      protos.google.pubsub.v1.ISubscription,
-      protos.google.pubsub.v1.ISubscription | null | undefined,
-      {} | null | undefined
-    >
-  ): void;
-  createSubscription(
-    request: protos.google.pubsub.v1.ISubscription,
-    callback: Callback<
-      protos.google.pubsub.v1.ISubscription,
-      protos.google.pubsub.v1.ISubscription | null | undefined,
-      {} | null | undefined
-    >
-  ): void;
   /**
    * Creates a subscription to a given topic. See the [resource name rules]
    * (https://cloud.google.com/pubsub/docs/admin#resource_names).
@@ -522,6 +495,33 @@ export class SubscriberClient {
    */
   createSubscription(
     request?: protos.google.pubsub.v1.ISubscription,
+    options?: CallOptions
+  ): Promise<
+    [
+      protos.google.pubsub.v1.ISubscription,
+      protos.google.pubsub.v1.ISubscription | undefined,
+      {} | undefined
+    ]
+  >;
+  createSubscription(
+    request: protos.google.pubsub.v1.ISubscription,
+    options: CallOptions,
+    callback: Callback<
+      protos.google.pubsub.v1.ISubscription,
+      protos.google.pubsub.v1.ISubscription | null | undefined,
+      {} | null | undefined
+    >
+  ): void;
+  createSubscription(
+    request: protos.google.pubsub.v1.ISubscription,
+    callback: Callback<
+      protos.google.pubsub.v1.ISubscription,
+      protos.google.pubsub.v1.ISubscription | null | undefined,
+      {} | null | undefined
+    >
+  ): void;
+  createSubscription(
+    request?: protos.google.pubsub.v1.ISubscription,
     optionsOrCallback?:
       | CallOptions
       | Callback<
@@ -559,6 +559,26 @@ export class SubscriberClient {
     this.initialize();
     return this.innerApiCalls.createSubscription(request, options, callback);
   }
+  /**
+   * Gets the configuration details of a subscription.
+   *
+   * @param {Object} request
+   *   The request object that will be sent.
+   * @param {string} request.subscription
+   *   Required. The name of the subscription to get.
+   *   Format is `projects/{project}/subscriptions/{sub}`.
+   * @param {object} [options]
+   *   Call options. See {@link https://googleapis.dev/nodejs/google-gax/latest/interfaces/CallOptions.html|CallOptions} for more details.
+   * @returns {Promise} - The promise which resolves to an array.
+   *   The first element of the array is an object representing [Subscription]{@link google.pubsub.v1.Subscription}.
+   *   Please see the
+   *   [documentation](https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#regular-methods)
+   *   for more details and examples.
+   * @example
+   * ```
+   * const [response] = await client.getSubscription(request);
+   * ```
+   */
   getSubscription(
     request?: protos.google.pubsub.v1.IGetSubscriptionRequest,
     options?: CallOptions
@@ -586,26 +606,6 @@ export class SubscriberClient {
       {} | null | undefined
     >
   ): void;
-  /**
-   * Gets the configuration details of a subscription.
-   *
-   * @param {Object} request
-   *   The request object that will be sent.
-   * @param {string} request.subscription
-   *   Required. The name of the subscription to get.
-   *   Format is `projects/{project}/subscriptions/{sub}`.
-   * @param {object} [options]
-   *   Call options. See {@link https://googleapis.dev/nodejs/google-gax/latest/interfaces/CallOptions.html|CallOptions} for more details.
-   * @returns {Promise} - The promise which resolves to an array.
-   *   The first element of the array is an object representing [Subscription]{@link google.pubsub.v1.Subscription}.
-   *   Please see the
-   *   [documentation](https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#regular-methods)
-   *   for more details and examples.
-   * @example
-   * ```
-   * const [response] = await client.getSubscription(request);
-   * ```
-   */
   getSubscription(
     request?: protos.google.pubsub.v1.IGetSubscriptionRequest,
     optionsOrCallback?:
@@ -645,6 +645,29 @@ export class SubscriberClient {
     this.initialize();
     return this.innerApiCalls.getSubscription(request, options, callback);
   }
+  /**
+   * Updates an existing subscription. Note that certain properties of a
+   * subscription, such as its topic, are not modifiable.
+   *
+   * @param {Object} request
+   *   The request object that will be sent.
+   * @param {google.pubsub.v1.Subscription} request.subscription
+   *   Required. The updated subscription object.
+   * @param {google.protobuf.FieldMask} request.updateMask
+   *   Required. Indicates which fields in the provided subscription to update.
+   *   Must be specified and non-empty.
+   * @param {object} [options]
+   *   Call options. See {@link https://googleapis.dev/nodejs/google-gax/latest/interfaces/CallOptions.html|CallOptions} for more details.
+   * @returns {Promise} - The promise which resolves to an array.
+   *   The first element of the array is an object representing [Subscription]{@link google.pubsub.v1.Subscription}.
+   *   Please see the
+   *   [documentation](https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#regular-methods)
+   *   for more details and examples.
+   * @example
+   * ```
+   * const [response] = await client.updateSubscription(request);
+   * ```
+   */
   updateSubscription(
     request?: protos.google.pubsub.v1.IUpdateSubscriptionRequest,
     options?: CallOptions
@@ -672,29 +695,6 @@ export class SubscriberClient {
       {} | null | undefined
     >
   ): void;
-  /**
-   * Updates an existing subscription. Note that certain properties of a
-   * subscription, such as its topic, are not modifiable.
-   *
-   * @param {Object} request
-   *   The request object that will be sent.
-   * @param {google.pubsub.v1.Subscription} request.subscription
-   *   Required. The updated subscription object.
-   * @param {google.protobuf.FieldMask} request.updateMask
-   *   Required. Indicates which fields in the provided subscription to update.
-   *   Must be specified and non-empty.
-   * @param {object} [options]
-   *   Call options. See {@link https://googleapis.dev/nodejs/google-gax/latest/interfaces/CallOptions.html|CallOptions} for more details.
-   * @returns {Promise} - The promise which resolves to an array.
-   *   The first element of the array is an object representing [Subscription]{@link google.pubsub.v1.Subscription}.
-   *   Please see the
-   *   [documentation](https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#regular-methods)
-   *   for more details and examples.
-   * @example
-   * ```
-   * const [response] = await client.updateSubscription(request);
-   * ```
-   */
   updateSubscription(
     request?: protos.google.pubsub.v1.IUpdateSubscriptionRequest,
     optionsOrCallback?:
@@ -734,6 +734,30 @@ export class SubscriberClient {
     this.initialize();
     return this.innerApiCalls.updateSubscription(request, options, callback);
   }
+  /**
+   * Deletes an existing subscription. All messages retained in the subscription
+   * are immediately dropped. Calls to `Pull` after deletion will return
+   * `NOT_FOUND`. After a subscription is deleted, a new one may be created with
+   * the same name, but the new one has no association with the old
+   * subscription or its topic unless the same topic is specified.
+   *
+   * @param {Object} request
+   *   The request object that will be sent.
+   * @param {string} request.subscription
+   *   Required. The subscription to delete.
+   *   Format is `projects/{project}/subscriptions/{sub}`.
+   * @param {object} [options]
+   *   Call options. See {@link https://googleapis.dev/nodejs/google-gax/latest/interfaces/CallOptions.html|CallOptions} for more details.
+   * @returns {Promise} - The promise which resolves to an array.
+   *   The first element of the array is an object representing [Empty]{@link google.protobuf.Empty}.
+   *   Please see the
+   *   [documentation](https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#regular-methods)
+   *   for more details and examples.
+   * @example
+   * ```
+   * const [response] = await client.deleteSubscription(request);
+   * ```
+   */
   deleteSubscription(
     request?: protos.google.pubsub.v1.IDeleteSubscriptionRequest,
     options?: CallOptions
@@ -761,30 +785,6 @@ export class SubscriberClient {
       {} | null | undefined
     >
   ): void;
-  /**
-   * Deletes an existing subscription. All messages retained in the subscription
-   * are immediately dropped. Calls to `Pull` after deletion will return
-   * `NOT_FOUND`. After a subscription is deleted, a new one may be created with
-   * the same name, but the new one has no association with the old
-   * subscription or its topic unless the same topic is specified.
-   *
-   * @param {Object} request
-   *   The request object that will be sent.
-   * @param {string} request.subscription
-   *   Required. The subscription to delete.
-   *   Format is `projects/{project}/subscriptions/{sub}`.
-   * @param {object} [options]
-   *   Call options. See {@link https://googleapis.dev/nodejs/google-gax/latest/interfaces/CallOptions.html|CallOptions} for more details.
-   * @returns {Promise} - The promise which resolves to an array.
-   *   The first element of the array is an object representing [Empty]{@link google.protobuf.Empty}.
-   *   Please see the
-   *   [documentation](https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#regular-methods)
-   *   for more details and examples.
-   * @example
-   * ```
-   * const [response] = await client.deleteSubscription(request);
-   * ```
-   */
   deleteSubscription(
     request?: protos.google.pubsub.v1.IDeleteSubscriptionRequest,
     optionsOrCallback?:
@@ -824,33 +824,6 @@ export class SubscriberClient {
     this.initialize();
     return this.innerApiCalls.deleteSubscription(request, options, callback);
   }
-  modifyAckDeadline(
-    request?: protos.google.pubsub.v1.IModifyAckDeadlineRequest,
-    options?: CallOptions
-  ): Promise<
-    [
-      protos.google.protobuf.IEmpty,
-      protos.google.pubsub.v1.IModifyAckDeadlineRequest | undefined,
-      {} | undefined
-    ]
-  >;
-  modifyAckDeadline(
-    request: protos.google.pubsub.v1.IModifyAckDeadlineRequest,
-    options: CallOptions,
-    callback: Callback<
-      protos.google.protobuf.IEmpty,
-      protos.google.pubsub.v1.IModifyAckDeadlineRequest | null | undefined,
-      {} | null | undefined
-    >
-  ): void;
-  modifyAckDeadline(
-    request: protos.google.pubsub.v1.IModifyAckDeadlineRequest,
-    callback: Callback<
-      protos.google.protobuf.IEmpty,
-      protos.google.pubsub.v1.IModifyAckDeadlineRequest | null | undefined,
-      {} | null | undefined
-    >
-  ): void;
   /**
    * Modifies the ack deadline for a specific message. This method is useful
    * to indicate that more time is needed to process a message by the
@@ -886,6 +859,33 @@ export class SubscriberClient {
    * const [response] = await client.modifyAckDeadline(request);
    * ```
    */
+  modifyAckDeadline(
+    request?: protos.google.pubsub.v1.IModifyAckDeadlineRequest,
+    options?: CallOptions
+  ): Promise<
+    [
+      protos.google.protobuf.IEmpty,
+      protos.google.pubsub.v1.IModifyAckDeadlineRequest | undefined,
+      {} | undefined
+    ]
+  >;
+  modifyAckDeadline(
+    request: protos.google.pubsub.v1.IModifyAckDeadlineRequest,
+    options: CallOptions,
+    callback: Callback<
+      protos.google.protobuf.IEmpty,
+      protos.google.pubsub.v1.IModifyAckDeadlineRequest | null | undefined,
+      {} | null | undefined
+    >
+  ): void;
+  modifyAckDeadline(
+    request: protos.google.pubsub.v1.IModifyAckDeadlineRequest,
+    callback: Callback<
+      protos.google.protobuf.IEmpty,
+      protos.google.pubsub.v1.IModifyAckDeadlineRequest | null | undefined,
+      {} | null | undefined
+    >
+  ): void;
   modifyAckDeadline(
     request?: protos.google.pubsub.v1.IModifyAckDeadlineRequest,
     optionsOrCallback?:
@@ -925,33 +925,6 @@ export class SubscriberClient {
     this.initialize();
     return this.innerApiCalls.modifyAckDeadline(request, options, callback);
   }
-  acknowledge(
-    request?: protos.google.pubsub.v1.IAcknowledgeRequest,
-    options?: CallOptions
-  ): Promise<
-    [
-      protos.google.protobuf.IEmpty,
-      protos.google.pubsub.v1.IAcknowledgeRequest | undefined,
-      {} | undefined
-    ]
-  >;
-  acknowledge(
-    request: protos.google.pubsub.v1.IAcknowledgeRequest,
-    options: CallOptions,
-    callback: Callback<
-      protos.google.protobuf.IEmpty,
-      protos.google.pubsub.v1.IAcknowledgeRequest | null | undefined,
-      {} | null | undefined
-    >
-  ): void;
-  acknowledge(
-    request: protos.google.pubsub.v1.IAcknowledgeRequest,
-    callback: Callback<
-      protos.google.protobuf.IEmpty,
-      protos.google.pubsub.v1.IAcknowledgeRequest | null | undefined,
-      {} | null | undefined
-    >
-  ): void;
   /**
    * Acknowledges the messages associated with the `ack_ids` in the
    * `AcknowledgeRequest`. The Pub/Sub system can remove the relevant messages
@@ -982,6 +955,33 @@ export class SubscriberClient {
    * const [response] = await client.acknowledge(request);
    * ```
    */
+  acknowledge(
+    request?: protos.google.pubsub.v1.IAcknowledgeRequest,
+    options?: CallOptions
+  ): Promise<
+    [
+      protos.google.protobuf.IEmpty,
+      protos.google.pubsub.v1.IAcknowledgeRequest | undefined,
+      {} | undefined
+    ]
+  >;
+  acknowledge(
+    request: protos.google.pubsub.v1.IAcknowledgeRequest,
+    options: CallOptions,
+    callback: Callback<
+      protos.google.protobuf.IEmpty,
+      protos.google.pubsub.v1.IAcknowledgeRequest | null | undefined,
+      {} | null | undefined
+    >
+  ): void;
+  acknowledge(
+    request: protos.google.pubsub.v1.IAcknowledgeRequest,
+    callback: Callback<
+      protos.google.protobuf.IEmpty,
+      protos.google.pubsub.v1.IAcknowledgeRequest | null | undefined,
+      {} | null | undefined
+    >
+  ): void;
   acknowledge(
     request?: protos.google.pubsub.v1.IAcknowledgeRequest,
     optionsOrCallback?:
@@ -1021,33 +1021,6 @@ export class SubscriberClient {
     this.initialize();
     return this.innerApiCalls.acknowledge(request, options, callback);
   }
-  pull(
-    request?: protos.google.pubsub.v1.IPullRequest,
-    options?: CallOptions
-  ): Promise<
-    [
-      protos.google.pubsub.v1.IPullResponse,
-      protos.google.pubsub.v1.IPullRequest | undefined,
-      {} | undefined
-    ]
-  >;
-  pull(
-    request: protos.google.pubsub.v1.IPullRequest,
-    options: CallOptions,
-    callback: Callback<
-      protos.google.pubsub.v1.IPullResponse,
-      protos.google.pubsub.v1.IPullRequest | null | undefined,
-      {} | null | undefined
-    >
-  ): void;
-  pull(
-    request: protos.google.pubsub.v1.IPullRequest,
-    callback: Callback<
-      protos.google.pubsub.v1.IPullResponse,
-      protos.google.pubsub.v1.IPullRequest | null | undefined,
-      {} | null | undefined
-    >
-  ): void;
   /**
    * Pulls messages from the server. The server may return `UNAVAILABLE` if
    * there are too many concurrent pull requests pending for the given
@@ -1082,6 +1055,33 @@ export class SubscriberClient {
    * const [response] = await client.pull(request);
    * ```
    */
+  pull(
+    request?: protos.google.pubsub.v1.IPullRequest,
+    options?: CallOptions
+  ): Promise<
+    [
+      protos.google.pubsub.v1.IPullResponse,
+      protos.google.pubsub.v1.IPullRequest | undefined,
+      {} | undefined
+    ]
+  >;
+  pull(
+    request: protos.google.pubsub.v1.IPullRequest,
+    options: CallOptions,
+    callback: Callback<
+      protos.google.pubsub.v1.IPullResponse,
+      protos.google.pubsub.v1.IPullRequest | null | undefined,
+      {} | null | undefined
+    >
+  ): void;
+  pull(
+    request: protos.google.pubsub.v1.IPullRequest,
+    callback: Callback<
+      protos.google.pubsub.v1.IPullResponse,
+      protos.google.pubsub.v1.IPullRequest | null | undefined,
+      {} | null | undefined
+    >
+  ): void;
   pull(
     request?: protos.google.pubsub.v1.IPullRequest,
     optionsOrCallback?:
@@ -1121,33 +1121,6 @@ export class SubscriberClient {
     this.initialize();
     return this.innerApiCalls.pull(request, options, callback);
   }
-  modifyPushConfig(
-    request?: protos.google.pubsub.v1.IModifyPushConfigRequest,
-    options?: CallOptions
-  ): Promise<
-    [
-      protos.google.protobuf.IEmpty,
-      protos.google.pubsub.v1.IModifyPushConfigRequest | undefined,
-      {} | undefined
-    ]
-  >;
-  modifyPushConfig(
-    request: protos.google.pubsub.v1.IModifyPushConfigRequest,
-    options: CallOptions,
-    callback: Callback<
-      protos.google.protobuf.IEmpty,
-      protos.google.pubsub.v1.IModifyPushConfigRequest | null | undefined,
-      {} | null | undefined
-    >
-  ): void;
-  modifyPushConfig(
-    request: protos.google.pubsub.v1.IModifyPushConfigRequest,
-    callback: Callback<
-      protos.google.protobuf.IEmpty,
-      protos.google.pubsub.v1.IModifyPushConfigRequest | null | undefined,
-      {} | null | undefined
-    >
-  ): void;
   /**
    * Modifies the `PushConfig` for a specified subscription.
    *
@@ -1180,6 +1153,33 @@ export class SubscriberClient {
    * const [response] = await client.modifyPushConfig(request);
    * ```
    */
+  modifyPushConfig(
+    request?: protos.google.pubsub.v1.IModifyPushConfigRequest,
+    options?: CallOptions
+  ): Promise<
+    [
+      protos.google.protobuf.IEmpty,
+      protos.google.pubsub.v1.IModifyPushConfigRequest | undefined,
+      {} | undefined
+    ]
+  >;
+  modifyPushConfig(
+    request: protos.google.pubsub.v1.IModifyPushConfigRequest,
+    options: CallOptions,
+    callback: Callback<
+      protos.google.protobuf.IEmpty,
+      protos.google.pubsub.v1.IModifyPushConfigRequest | null | undefined,
+      {} | null | undefined
+    >
+  ): void;
+  modifyPushConfig(
+    request: protos.google.pubsub.v1.IModifyPushConfigRequest,
+    callback: Callback<
+      protos.google.protobuf.IEmpty,
+      protos.google.pubsub.v1.IModifyPushConfigRequest | null | undefined,
+      {} | null | undefined
+    >
+  ): void;
   modifyPushConfig(
     request?: protos.google.pubsub.v1.IModifyPushConfigRequest,
     optionsOrCallback?:
@@ -1219,6 +1219,30 @@ export class SubscriberClient {
     this.initialize();
     return this.innerApiCalls.modifyPushConfig(request, options, callback);
   }
+  /**
+   * Gets the configuration details of a snapshot. Snapshots are used in
+   * <a href="https://cloud.google.com/pubsub/docs/replay-overview">Seek</a>
+   * operations, which allow you to manage message acknowledgments in bulk. That
+   * is, you can set the acknowledgment state of messages in an existing
+   * subscription to the state captured by a snapshot.
+   *
+   * @param {Object} request
+   *   The request object that will be sent.
+   * @param {string} request.snapshot
+   *   Required. The name of the snapshot to get.
+   *   Format is `projects/{project}/snapshots/{snap}`.
+   * @param {object} [options]
+   *   Call options. See {@link https://googleapis.dev/nodejs/google-gax/latest/interfaces/CallOptions.html|CallOptions} for more details.
+   * @returns {Promise} - The promise which resolves to an array.
+   *   The first element of the array is an object representing [Snapshot]{@link google.pubsub.v1.Snapshot}.
+   *   Please see the
+   *   [documentation](https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#regular-methods)
+   *   for more details and examples.
+   * @example
+   * ```
+   * const [response] = await client.getSnapshot(request);
+   * ```
+   */
   getSnapshot(
     request?: protos.google.pubsub.v1.IGetSnapshotRequest,
     options?: CallOptions
@@ -1246,30 +1270,6 @@ export class SubscriberClient {
       {} | null | undefined
     >
   ): void;
-  /**
-   * Gets the configuration details of a snapshot. Snapshots are used in
-   * <a href="https://cloud.google.com/pubsub/docs/replay-overview">Seek</a>
-   * operations, which allow you to manage message acknowledgments in bulk. That
-   * is, you can set the acknowledgment state of messages in an existing
-   * subscription to the state captured by a snapshot.
-   *
-   * @param {Object} request
-   *   The request object that will be sent.
-   * @param {string} request.snapshot
-   *   Required. The name of the snapshot to get.
-   *   Format is `projects/{project}/snapshots/{snap}`.
-   * @param {object} [options]
-   *   Call options. See {@link https://googleapis.dev/nodejs/google-gax/latest/interfaces/CallOptions.html|CallOptions} for more details.
-   * @returns {Promise} - The promise which resolves to an array.
-   *   The first element of the array is an object representing [Snapshot]{@link google.pubsub.v1.Snapshot}.
-   *   Please see the
-   *   [documentation](https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#regular-methods)
-   *   for more details and examples.
-   * @example
-   * ```
-   * const [response] = await client.getSnapshot(request);
-   * ```
-   */
   getSnapshot(
     request?: protos.google.pubsub.v1.IGetSnapshotRequest,
     optionsOrCallback?:
@@ -1309,33 +1309,6 @@ export class SubscriberClient {
     this.initialize();
     return this.innerApiCalls.getSnapshot(request, options, callback);
   }
-  createSnapshot(
-    request?: protos.google.pubsub.v1.ICreateSnapshotRequest,
-    options?: CallOptions
-  ): Promise<
-    [
-      protos.google.pubsub.v1.ISnapshot,
-      protos.google.pubsub.v1.ICreateSnapshotRequest | undefined,
-      {} | undefined
-    ]
-  >;
-  createSnapshot(
-    request: protos.google.pubsub.v1.ICreateSnapshotRequest,
-    options: CallOptions,
-    callback: Callback<
-      protos.google.pubsub.v1.ISnapshot,
-      protos.google.pubsub.v1.ICreateSnapshotRequest | null | undefined,
-      {} | null | undefined
-    >
-  ): void;
-  createSnapshot(
-    request: protos.google.pubsub.v1.ICreateSnapshotRequest,
-    callback: Callback<
-      protos.google.pubsub.v1.ISnapshot,
-      protos.google.pubsub.v1.ICreateSnapshotRequest | null | undefined,
-      {} | null | undefined
-    >
-  ): void;
   /**
    * Creates a snapshot from the requested subscription. Snapshots are used in
    * [Seek](https://cloud.google.com/pubsub/docs/replay-overview) operations,
@@ -1390,6 +1363,33 @@ export class SubscriberClient {
    */
   createSnapshot(
     request?: protos.google.pubsub.v1.ICreateSnapshotRequest,
+    options?: CallOptions
+  ): Promise<
+    [
+      protos.google.pubsub.v1.ISnapshot,
+      protos.google.pubsub.v1.ICreateSnapshotRequest | undefined,
+      {} | undefined
+    ]
+  >;
+  createSnapshot(
+    request: protos.google.pubsub.v1.ICreateSnapshotRequest,
+    options: CallOptions,
+    callback: Callback<
+      protos.google.pubsub.v1.ISnapshot,
+      protos.google.pubsub.v1.ICreateSnapshotRequest | null | undefined,
+      {} | null | undefined
+    >
+  ): void;
+  createSnapshot(
+    request: protos.google.pubsub.v1.ICreateSnapshotRequest,
+    callback: Callback<
+      protos.google.pubsub.v1.ISnapshot,
+      protos.google.pubsub.v1.ICreateSnapshotRequest | null | undefined,
+      {} | null | undefined
+    >
+  ): void;
+  createSnapshot(
+    request?: protos.google.pubsub.v1.ICreateSnapshotRequest,
     optionsOrCallback?:
       | CallOptions
       | Callback<
@@ -1427,33 +1427,6 @@ export class SubscriberClient {
     this.initialize();
     return this.innerApiCalls.createSnapshot(request, options, callback);
   }
-  updateSnapshot(
-    request?: protos.google.pubsub.v1.IUpdateSnapshotRequest,
-    options?: CallOptions
-  ): Promise<
-    [
-      protos.google.pubsub.v1.ISnapshot,
-      protos.google.pubsub.v1.IUpdateSnapshotRequest | undefined,
-      {} | undefined
-    ]
-  >;
-  updateSnapshot(
-    request: protos.google.pubsub.v1.IUpdateSnapshotRequest,
-    options: CallOptions,
-    callback: Callback<
-      protos.google.pubsub.v1.ISnapshot,
-      protos.google.pubsub.v1.IUpdateSnapshotRequest | null | undefined,
-      {} | null | undefined
-    >
-  ): void;
-  updateSnapshot(
-    request: protos.google.pubsub.v1.IUpdateSnapshotRequest,
-    callback: Callback<
-      protos.google.pubsub.v1.ISnapshot,
-      protos.google.pubsub.v1.IUpdateSnapshotRequest | null | undefined,
-      {} | null | undefined
-    >
-  ): void;
   /**
    * Updates an existing snapshot. Snapshots are used in
    * <a href="https://cloud.google.com/pubsub/docs/replay-overview">Seek</a>
@@ -1481,6 +1454,33 @@ export class SubscriberClient {
    * const [response] = await client.updateSnapshot(request);
    * ```
    */
+  updateSnapshot(
+    request?: protos.google.pubsub.v1.IUpdateSnapshotRequest,
+    options?: CallOptions
+  ): Promise<
+    [
+      protos.google.pubsub.v1.ISnapshot,
+      protos.google.pubsub.v1.IUpdateSnapshotRequest | undefined,
+      {} | undefined
+    ]
+  >;
+  updateSnapshot(
+    request: protos.google.pubsub.v1.IUpdateSnapshotRequest,
+    options: CallOptions,
+    callback: Callback<
+      protos.google.pubsub.v1.ISnapshot,
+      protos.google.pubsub.v1.IUpdateSnapshotRequest | null | undefined,
+      {} | null | undefined
+    >
+  ): void;
+  updateSnapshot(
+    request: protos.google.pubsub.v1.IUpdateSnapshotRequest,
+    callback: Callback<
+      protos.google.pubsub.v1.ISnapshot,
+      protos.google.pubsub.v1.IUpdateSnapshotRequest | null | undefined,
+      {} | null | undefined
+    >
+  ): void;
   updateSnapshot(
     request?: protos.google.pubsub.v1.IUpdateSnapshotRequest,
     optionsOrCallback?:
@@ -1520,33 +1520,6 @@ export class SubscriberClient {
     this.initialize();
     return this.innerApiCalls.updateSnapshot(request, options, callback);
   }
-  deleteSnapshot(
-    request?: protos.google.pubsub.v1.IDeleteSnapshotRequest,
-    options?: CallOptions
-  ): Promise<
-    [
-      protos.google.protobuf.IEmpty,
-      protos.google.pubsub.v1.IDeleteSnapshotRequest | undefined,
-      {} | undefined
-    ]
-  >;
-  deleteSnapshot(
-    request: protos.google.pubsub.v1.IDeleteSnapshotRequest,
-    options: CallOptions,
-    callback: Callback<
-      protos.google.protobuf.IEmpty,
-      protos.google.pubsub.v1.IDeleteSnapshotRequest | null | undefined,
-      {} | null | undefined
-    >
-  ): void;
-  deleteSnapshot(
-    request: protos.google.pubsub.v1.IDeleteSnapshotRequest,
-    callback: Callback<
-      protos.google.protobuf.IEmpty,
-      protos.google.pubsub.v1.IDeleteSnapshotRequest | null | undefined,
-      {} | null | undefined
-    >
-  ): void;
   /**
    * Removes an existing snapshot. Snapshots are used in [Seek]
    * (https://cloud.google.com/pubsub/docs/replay-overview) operations, which
@@ -1575,6 +1548,33 @@ export class SubscriberClient {
    * const [response] = await client.deleteSnapshot(request);
    * ```
    */
+  deleteSnapshot(
+    request?: protos.google.pubsub.v1.IDeleteSnapshotRequest,
+    options?: CallOptions
+  ): Promise<
+    [
+      protos.google.protobuf.IEmpty,
+      protos.google.pubsub.v1.IDeleteSnapshotRequest | undefined,
+      {} | undefined
+    ]
+  >;
+  deleteSnapshot(
+    request: protos.google.pubsub.v1.IDeleteSnapshotRequest,
+    options: CallOptions,
+    callback: Callback<
+      protos.google.protobuf.IEmpty,
+      protos.google.pubsub.v1.IDeleteSnapshotRequest | null | undefined,
+      {} | null | undefined
+    >
+  ): void;
+  deleteSnapshot(
+    request: protos.google.pubsub.v1.IDeleteSnapshotRequest,
+    callback: Callback<
+      protos.google.protobuf.IEmpty,
+      protos.google.pubsub.v1.IDeleteSnapshotRequest | null | undefined,
+      {} | null | undefined
+    >
+  ): void;
   deleteSnapshot(
     request?: protos.google.pubsub.v1.IDeleteSnapshotRequest,
     optionsOrCallback?:
@@ -1614,33 +1614,6 @@ export class SubscriberClient {
     this.initialize();
     return this.innerApiCalls.deleteSnapshot(request, options, callback);
   }
-  seek(
-    request?: protos.google.pubsub.v1.ISeekRequest,
-    options?: CallOptions
-  ): Promise<
-    [
-      protos.google.pubsub.v1.ISeekResponse,
-      protos.google.pubsub.v1.ISeekRequest | undefined,
-      {} | undefined
-    ]
-  >;
-  seek(
-    request: protos.google.pubsub.v1.ISeekRequest,
-    options: CallOptions,
-    callback: Callback<
-      protos.google.pubsub.v1.ISeekResponse,
-      protos.google.pubsub.v1.ISeekRequest | null | undefined,
-      {} | null | undefined
-    >
-  ): void;
-  seek(
-    request: protos.google.pubsub.v1.ISeekRequest,
-    callback: Callback<
-      protos.google.pubsub.v1.ISeekResponse,
-      protos.google.pubsub.v1.ISeekRequest | null | undefined,
-      {} | null | undefined
-    >
-  ): void;
   /**
    * Seeks an existing subscription to a point in time or to a given snapshot,
    * whichever is provided in the request. Snapshots are used in [Seek]
@@ -1682,6 +1655,33 @@ export class SubscriberClient {
    * const [response] = await client.seek(request);
    * ```
    */
+  seek(
+    request?: protos.google.pubsub.v1.ISeekRequest,
+    options?: CallOptions
+  ): Promise<
+    [
+      protos.google.pubsub.v1.ISeekResponse,
+      protos.google.pubsub.v1.ISeekRequest | undefined,
+      {} | undefined
+    ]
+  >;
+  seek(
+    request: protos.google.pubsub.v1.ISeekRequest,
+    options: CallOptions,
+    callback: Callback<
+      protos.google.pubsub.v1.ISeekResponse,
+      protos.google.pubsub.v1.ISeekRequest | null | undefined,
+      {} | null | undefined
+    >
+  ): void;
+  seek(
+    request: protos.google.pubsub.v1.ISeekRequest,
+    callback: Callback<
+      protos.google.pubsub.v1.ISeekResponse,
+      protos.google.pubsub.v1.ISeekRequest | null | undefined,
+      {} | null | undefined
+    >
+  ): void;
   seek(
     request?: protos.google.pubsub.v1.ISeekRequest,
     optionsOrCallback?:
@@ -1754,33 +1754,6 @@ export class SubscriberClient {
     return this.innerApiCalls.streamingPull(options);
   }
 
-  listSubscriptions(
-    request?: protos.google.pubsub.v1.IListSubscriptionsRequest,
-    options?: CallOptions
-  ): Promise<
-    [
-      protos.google.pubsub.v1.ISubscription[],
-      protos.google.pubsub.v1.IListSubscriptionsRequest | null,
-      protos.google.pubsub.v1.IListSubscriptionsResponse
-    ]
-  >;
-  listSubscriptions(
-    request: protos.google.pubsub.v1.IListSubscriptionsRequest,
-    options: CallOptions,
-    callback: PaginationCallback<
-      protos.google.pubsub.v1.IListSubscriptionsRequest,
-      protos.google.pubsub.v1.IListSubscriptionsResponse | null | undefined,
-      protos.google.pubsub.v1.ISubscription
-    >
-  ): void;
-  listSubscriptions(
-    request: protos.google.pubsub.v1.IListSubscriptionsRequest,
-    callback: PaginationCallback<
-      protos.google.pubsub.v1.IListSubscriptionsRequest,
-      protos.google.pubsub.v1.IListSubscriptionsResponse | null | undefined,
-      protos.google.pubsub.v1.ISubscription
-    >
-  ): void;
   /**
    * Lists matching subscriptions.
    *
@@ -1808,6 +1781,33 @@ export class SubscriberClient {
    *   [documentation](https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#auto-pagination)
    *   for more details and examples.
    */
+  listSubscriptions(
+    request?: protos.google.pubsub.v1.IListSubscriptionsRequest,
+    options?: CallOptions
+  ): Promise<
+    [
+      protos.google.pubsub.v1.ISubscription[],
+      protos.google.pubsub.v1.IListSubscriptionsRequest | null,
+      protos.google.pubsub.v1.IListSubscriptionsResponse
+    ]
+  >;
+  listSubscriptions(
+    request: protos.google.pubsub.v1.IListSubscriptionsRequest,
+    options: CallOptions,
+    callback: PaginationCallback<
+      protos.google.pubsub.v1.IListSubscriptionsRequest,
+      protos.google.pubsub.v1.IListSubscriptionsResponse | null | undefined,
+      protos.google.pubsub.v1.ISubscription
+    >
+  ): void;
+  listSubscriptions(
+    request: protos.google.pubsub.v1.IListSubscriptionsRequest,
+    callback: PaginationCallback<
+      protos.google.pubsub.v1.IListSubscriptionsRequest,
+      protos.google.pubsub.v1.IListSubscriptionsResponse | null | undefined,
+      protos.google.pubsub.v1.ISubscription
+    >
+  ): void;
   listSubscriptions(
     request?: protos.google.pubsub.v1.IListSubscriptionsRequest,
     optionsOrCallback?:
@@ -1948,33 +1948,6 @@ export class SubscriberClient {
       callSettings
     ) as AsyncIterable<protos.google.pubsub.v1.ISubscription>;
   }
-  listSnapshots(
-    request?: protos.google.pubsub.v1.IListSnapshotsRequest,
-    options?: CallOptions
-  ): Promise<
-    [
-      protos.google.pubsub.v1.ISnapshot[],
-      protos.google.pubsub.v1.IListSnapshotsRequest | null,
-      protos.google.pubsub.v1.IListSnapshotsResponse
-    ]
-  >;
-  listSnapshots(
-    request: protos.google.pubsub.v1.IListSnapshotsRequest,
-    options: CallOptions,
-    callback: PaginationCallback<
-      protos.google.pubsub.v1.IListSnapshotsRequest,
-      protos.google.pubsub.v1.IListSnapshotsResponse | null | undefined,
-      protos.google.pubsub.v1.ISnapshot
-    >
-  ): void;
-  listSnapshots(
-    request: protos.google.pubsub.v1.IListSnapshotsRequest,
-    callback: PaginationCallback<
-      protos.google.pubsub.v1.IListSnapshotsRequest,
-      protos.google.pubsub.v1.IListSnapshotsResponse | null | undefined,
-      protos.google.pubsub.v1.ISnapshot
-    >
-  ): void;
   /**
    * Lists the existing snapshots. Snapshots are used in [Seek](
    * https://cloud.google.com/pubsub/docs/replay-overview) operations, which
@@ -2006,6 +1979,33 @@ export class SubscriberClient {
    *   [documentation](https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#auto-pagination)
    *   for more details and examples.
    */
+  listSnapshots(
+    request?: protos.google.pubsub.v1.IListSnapshotsRequest,
+    options?: CallOptions
+  ): Promise<
+    [
+      protos.google.pubsub.v1.ISnapshot[],
+      protos.google.pubsub.v1.IListSnapshotsRequest | null,
+      protos.google.pubsub.v1.IListSnapshotsResponse
+    ]
+  >;
+  listSnapshots(
+    request: protos.google.pubsub.v1.IListSnapshotsRequest,
+    options: CallOptions,
+    callback: PaginationCallback<
+      protos.google.pubsub.v1.IListSnapshotsRequest,
+      protos.google.pubsub.v1.IListSnapshotsResponse | null | undefined,
+      protos.google.pubsub.v1.ISnapshot
+    >
+  ): void;
+  listSnapshots(
+    request: protos.google.pubsub.v1.IListSnapshotsRequest,
+    callback: PaginationCallback<
+      protos.google.pubsub.v1.IListSnapshotsRequest,
+      protos.google.pubsub.v1.IListSnapshotsResponse | null | undefined,
+      protos.google.pubsub.v1.ISnapshot
+    >
+  ): void;
   listSnapshots(
     request?: protos.google.pubsub.v1.IListSnapshotsRequest,
     optionsOrCallback?:


### PR DESCRIPTION
As we move our ref docs to cloud.google.com, we rely on TSDoc rather JSDoc.

TSDoc expects comments before the first overloaded function, we
currently have those on the last function. Those comments don't make
it into the d.ts files. We need to move comments to the first
overloaded function rather than the last one.

Internally b/190631834

Script used: https://github.com/fhinkel/cloud-rad-script/blob/main/moveComments.js
