### PR TITLE
fix: temporary hold-back on google-gax to avoid timeout issues

### DIFF
--- a/package.json
+++ b/package.json
@@ -58,7 +58,7 @@
     "arrify": "^2.0.0",
     "extend": "^3.0.2",
     "google-auth-library": "^7.0.0",
-    "google-gax": "^2.24.1",
+    "google-gax": "2.25.3",
     "is-stream-ended": "^0.1.4",
     "lodash.snakecase": "^4.1.1",
     "p-defer": "^3.0.0"


### PR DESCRIPTION
Temporary hold-back on google-gax to avoid timeout issues by https://github.com/googleapis/gax-nodejs/pull/1100

This is related to https://github.com/googleapis/nodejs-pubsub/issues/1425

(but does not fix, please hold that issue open for now so we have a todo to remove this block)
