### PR TITLE
samples: topic publish() method is deprecated

### DIFF
--- a/samples/publishMessage.js
+++ b/samples/publishMessage.js
@@ -52,7 +52,7 @@ function main(
     try {
       const messageId = await pubSubClient
         .topic(topicNameOrId)
-        .publishMessage({data:dataBuffer});
+        .publishMessage({data: dataBuffer});
       console.log(`Message ${messageId} published.`);
     } catch (error) {
       console.error(`Received error while publishing: ${error.message}`);

--- a/samples/publishMessage.js
+++ b/samples/publishMessage.js
@@ -52,7 +52,7 @@ function main(
     try {
       const messageId = await pubSubClient
         .topic(topicNameOrId)
-        .publish(dataBuffer);
+        .publishMessage({data:dataBuffer});
       console.log(`Message ${messageId} published.`);
     } catch (error) {
       console.error(`Received error while publishing: ${error.message}`);


### PR DESCRIPTION
The `publish()` method is deprecated in favor of `publishMessage()` and the latter requires an object.
