### PR TITLE
fix: detect subscription properties and warn for exactly-once

### DIFF
--- a/src/subscriber.ts
+++ b/src/subscriber.ts
@@ -35,7 +35,6 @@ export type PullResponse = google.pubsub.v1.IStreamingPullResponse;
 export type SubscriptionProperties =
   google.pubsub.v1.StreamingPullResponse.ISubscriptionProperties;
 
-
 /**
  * Date object with nanosecond precision. Supports all standard Date arguments
  * in addition to several custom types.

--- a/src/util.ts
+++ b/src/util.ts
@@ -40,3 +40,35 @@ export function promisifySome<T>(
 }
 
 export function noop() {}
+
+/**
+ * Provides a very simple throttling capability for tasks like error logs.
+ * This ensures that no task is actually completed unless N millis have passed
+ * since the last one.
+ *
+ * @private
+ */
+export class Throttler {
+  minMillis: number;
+  lastTime?: number;
+
+  constructor(minMillis: number) {
+    this.minMillis = minMillis;
+  }
+
+  /**
+   * Performs the task requested, if enough time has passed since the
+   * last successful call.
+   */
+  doMaybe(task: Function) {
+    const now = Date.now();
+    const doTask =
+      !this.lastTime ||
+      (this.lastTime && now - this.lastTime >= this.minMillis);
+
+    if (doTask) {
+      task();
+      this.lastTime = now;
+    }
+  }
+}

--- a/test/util.ts
+++ b/test/util.ts
@@ -1,4 +1,4 @@
-// Copyright 2021 Google LLC
+// Copyright 2022 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/test/util.ts
+++ b/test/util.ts
@@ -1,18 +1,16 @@
-/*!
- * Copyright 2022 Google Inc. All Rights Reserved.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
+// Copyright 2021 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 
 import {describe, it} from 'mocha';
 import {Throttler} from '../src/util';

--- a/test/util.ts
+++ b/test/util.ts
@@ -1,0 +1,46 @@
+/*!
+ * Copyright 2017 Google Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import {describe, it} from 'mocha';
+import {Throttler} from '../src/util';
+import * as assert from 'assert';
+
+describe('utils', () => {
+  describe('Throttler', () => {
+    it('does not allow too many calls through at once', async () => {
+      const throttler = new Throttler(300);
+      let totalCalls = '';
+
+      // This one should succeed.
+      throttler.doMaybe(() => {
+        totalCalls += 'FIRST';
+      });
+
+      // This one should fail.
+      throttler.doMaybe(() => {
+        totalCalls += 'SECOND';
+      });
+
+      // This one should succeed.
+      await new Promise(r => setTimeout(r, 1000));
+      throttler.doMaybe(() => {
+        totalCalls += 'THIRD';
+      });
+
+      assert.strictEqual(totalCalls, 'FIRSTTHIRD');
+    });
+  });
+});

--- a/test/util.ts
+++ b/test/util.ts
@@ -1,5 +1,5 @@
 /*!
- * Copyright 2017 Google Inc. All Rights Reserved.
+ * Copyright 2022 Google Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/util.ts
+++ b/test/util.ts
@@ -18,7 +18,7 @@ import * as assert from 'assert';
 
 describe('utils', () => {
   describe('Throttler', () => {
-    it('does not allow too many calls through at once', async () => {
+    it('does not allow too many calls through at once', () => {
       const throttler = new Throttler(300);
       let totalCalls = '';
 
@@ -32,8 +32,10 @@ describe('utils', () => {
         totalCalls += 'SECOND';
       });
 
+      // Simulate time passing.
+      throttler.lastTime! -= 1000;
+
       // This one should succeed.
-      await new Promise(r => setTimeout(r, 1000));
       throttler.doMaybe(() => {
         totalCalls += 'THIRD';
       });


### PR DESCRIPTION
This catches the subscription properties from the first delivered message, and warns the user if exactly-once is enabled. This is a feature in progress for the Node library, so the exactly-once features will not be available yet, and incorrectly used semantics may cause problems with an exactly-once subscription.
