### PR TITLE
fix: pin @opentelemetry/semantic-conventions for Node 12 support

### DIFF
--- a/package.json
+++ b/package.json
@@ -52,7 +52,7 @@
     "@google-cloud/projectify": "^2.0.0",
     "@google-cloud/promisify": "^2.0.0",
     "@opentelemetry/api": "^1.0.0",
-    "@opentelemetry/semantic-conventions": "^1.0.0",
+    "@opentelemetry/semantic-conventions": "~1.3.0",
     "@types/duplexify": "^3.6.0",
     "@types/long": "^4.0.0",
     "arrify": "^2.0.0",


### PR DESCRIPTION
Related to: https://github.com/open-telemetry/opentelemetry-js/pull/3065

We'll need to unpin when we finish deprecating Node 12 as well.
