### PR TITLE
build: pin jsdoc 3.6.7 for Node 12 support

### DIFF
--- a/package.json
+++ b/package.json
@@ -81,7 +81,7 @@
     "codecov": "^3.0.0",
     "execa": "^5.0.0",
     "gts": "^3.1.0",
-    "jsdoc": "^3.6.2",
+    "jsdoc": "3.6.7",
     "jsdoc-fresh": "^2.0.0",
     "jsdoc-region-tag": "^2.0.0",
     "linkinator": "^4.0.0",


### PR DESCRIPTION
Fixes: https://github.com/googleapis/nodejs-pubsub/issues/1592
