### PR TITLE
fix: wait for 'drain' as well

### DIFF
--- a/src/publisher/index.ts
+++ b/src/publisher/index.ts
@@ -129,7 +129,7 @@ export class Publisher {
     );
 
     const allPublishes = Promise.all(
-      toDrain.map(q => promisify(q.publish.bind(q))())
+      toDrain.map(q => promisify(q.publish).bind(q)())
     );
 
     allPublishes

--- a/test/publisher/index.ts
+++ b/test/publisher/index.ts
@@ -349,9 +349,9 @@ describe('Publisher', () => {
           .callsFake((messages, callbacks, callback) => {
             // Simulate the drain taking longer than the publishes. This can
             // happen if more messages are queued during the publish().
-            setTimeout(() => {
+            process.nextTick(() => {
               publisher.queue.emit('drain');
-            }, 50);
+            });
             if (typeof callback === 'function') callback(null);
           });
 
@@ -364,9 +364,9 @@ describe('Publisher', () => {
             // Simulate the drain taking longer than the publishes. This can
             // happen on some ordered queue scenarios, especially if we have more
             // than one queue to empty.
-            setTimeout(() => {
+            process.nextTick(() => {
               queue.emit('drain');
-            }, 50);
+            });
             if (typeof callback === 'function') callback(null);
           });
 
@@ -507,9 +507,9 @@ describe('Publisher', () => {
         .callsFake((messages, callbacks, callback) => {
           // Simulate the drain taking longer than the publishes. This can
           // happen if more messages are queued during the publish().
-          setTimeout(() => {
+          process.nextTick(() => {
             publisher.queue.emit('drain');
-          }, 50);
+          });
           if (typeof callback === 'function') callback(null);
         });
 

--- a/test/publisher/index.ts
+++ b/test/publisher/index.ts
@@ -347,6 +347,11 @@ describe('Publisher', () => {
         sandbox
           .stub(FakeQueue.prototype, '_publish')
           .callsFake((messages, callbacks, callback) => {
+            // Simulate the drain taking longer than the publishes. This can
+            // happen if more messages are queued during the publish().
+            setTimeout(() => {
+              publisher.queue.emit('drain');
+            }, 50);
             if (typeof callback === 'function') callback(null);
           });
 
@@ -356,7 +361,12 @@ describe('Publisher', () => {
             const queue = publisher.orderedQueues.get(
               orderingKey
             ) as unknown as FakeOrderedQueue;
-            queue.emit('drain');
+            // Simulate the drain taking longer than the publishes. This can
+            // happen on some ordered queue scenarios, especially if we have more
+            // than one queue to empty.
+            setTimeout(() => {
+              queue.emit('drain');
+            }, 50);
             if (typeof callback === 'function') callback(null);
           });
 
@@ -495,6 +505,11 @@ describe('Publisher', () => {
       sandbox
         .stub(publisher.queue, '_publish')
         .callsFake((messages, callbacks, callback) => {
+          // Simulate the drain taking longer than the publishes. This can
+          // happen if more messages are queued during the publish().
+          setTimeout(() => {
+            publisher.queue.emit('drain');
+          }, 50);
           if (typeof callback === 'function') callback(null);
         });
 


### PR DESCRIPTION
It's possible to end up in a situation where more publishes are pending when publish() is called, but they aren't actually waited for. This adds 'drain' event support to the main publisher queue and waits for 'drain' on all queues before calling it done.

Maybe fixes #1620 🦕
