### PR TITLE
docs: update Cloud API reference location

### DIFF
--- a/.readme-partials.yml
+++ b/.readme-partials.yml
@@ -2,7 +2,7 @@ introduction: |-
         [Cloud Pub/Sub](https://cloud.google.com/pubsub/docs) is a fully-managed real-time messaging service that allows
         you to send and receive messages between independent applications.
 
-        This document contains links to an [API reference](https://googleapis.dev/nodejs/pubsub/latest/index.html#reference), samples,
+        This document contains links to an [API reference](https://cloud.google.com/nodejs/docs/reference/pubsub/latest/overview), samples,
         and other resources useful to developing Node.js applications.
         For additional help developing Pub/Sub applications, in Node.js and other languages, see our
         [Pub/Sub quickstart](https://cloud.google.com/pubsub/docs/quickstart-client-libraries),

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@
 [Cloud Pub/Sub](https://cloud.google.com/pubsub/docs) is a fully-managed real-time messaging service that allows
 you to send and receive messages between independent applications.
 
-This document contains links to an [API reference](https://googleapis.dev/nodejs/pubsub/latest/index.html#reference), samples,
+This document contains links to an [API reference](https://cloud.google.com/nodejs/docs/reference/pubsub/latest/overview), samples,
 and other resources useful to developing Node.js applications.
 For additional help developing Pub/Sub applications, in Node.js and other languages, see our
 [Pub/Sub quickstart](https://cloud.google.com/pubsub/docs/quickstart-client-libraries),

--- a/samples/README.md
+++ b/samples/README.md
@@ -9,7 +9,7 @@
 [Cloud Pub/Sub](https://cloud.google.com/pubsub/docs) is a fully-managed real-time messaging service that allows
 you to send and receive messages between independent applications.
 
-This document contains links to an [API reference](https://googleapis.dev/nodejs/pubsub/latest/index.html#reference), samples,
+This document contains links to an [API reference](https://cloud.google.com/nodejs/docs/reference/pubsub/latest/overview), samples,
 and other resources useful to developing Node.js applications.
 For additional help developing Pub/Sub applications, in Node.js and other languages, see our
 [Pub/Sub quickstart](https://cloud.google.com/pubsub/docs/quickstart-client-libraries),

--- a/system-test/fixtures/sample/package.json
+++ b/system-test/fixtures/sample/package.json
@@ -17,7 +17,7 @@
   },
   "devDependencies": {
     "@types/node": "^18.0.0",
-    "typescript": "^3.0.0",
-    "gts": "^2.0.0"
+    "typescript": "^4.6.4",
+    "gts": "^3.1.0"
   }
 }


### PR DESCRIPTION
Fixes: https://github.com/googleapis/nodejs-pubsub/issues/1536
