### PR TITLE
fix: don't do multiple drains per publish() in message queues unless requested

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,7 @@
 /build/
 system-test/secrets.js
 system-test/*key.json
+samples/**/build
 *.lock
 .DS_Store
 package-lock.json

--- a/src/publisher/index.ts
+++ b/src/publisher/index.ts
@@ -119,7 +119,7 @@ export class Publisher {
             const flushResolver = () => {
               resolve();
 
-              // flush() maybe called more than once, so remove these
+              // flush() may be called more than once, so remove these
               // event listeners after we've completed flush().
               q.removeListener('drain', flushResolver);
             };
@@ -129,7 +129,7 @@ export class Publisher {
     );
 
     const allPublishes = Promise.all(
-      toDrain.map(q => promisify(q.publish).bind(q)())
+      toDrain.map(q => promisify(q.publishDrain).bind(q)())
     );
 
     allPublishes

--- a/test/publisher/index.ts
+++ b/test/publisher/index.ts
@@ -63,6 +63,9 @@ class FakeQueue extends EventEmitter {
   publish(callback: (err: Error | null) => void) {
     this._publish([], [], callback);
   }
+  publishDrain(callback: (err: Error | null) => void) {
+    this.publish(callback);
+  }
   _publish(
     // eslint-disable-next-line @typescript-eslint/no-unused-vars
     messages: p.PubsubMessage[],
@@ -84,6 +87,9 @@ class FakeOrderedQueue extends FakeQueue {
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
   publish(callback: (err: Error | null) => void) {
     this._publish([], [], callback);
+  }
+  publishDrain(callback: (err: Error | null) => void) {
+    this.publish(callback);
   }
   _publish(
     // eslint-disable-next-line @typescript-eslint/no-unused-vars


### PR DESCRIPTION
Fixes: https://github.com/googleapis/nodejs-pubsub/issues/1690
