### PR TITLE
fix: handle receipt modAck and lease extensions with exactly-once delivery correctly

### DIFF
--- a/src/lease-manager.ts
+++ b/src/lease-manager.ts
@@ -15,7 +15,7 @@
  */
 
 import {EventEmitter} from 'events';
-import {Message, Subscriber} from './subscriber';
+import {AckError, Message, Subscriber} from './subscriber';
 import {defaultOptions} from './default-options';
 
 export interface FlowControlOptions {
@@ -258,9 +258,10 @@ export class LeaseManager extends EventEmitter {
 
       if (lifespan < this._options.maxExtensionMinutes!) {
         if (this._subscriber.isExactlyOnceDelivery) {
-          message.modAckWithResponse(deadline).catch(() => {
+          message.modAckWithResponse(deadline).catch(e => {
             // In the case of a permanent failure (temporary failures are retried),
             // we need to stop trying to lease-manage the message.
+            message.ackFailed(e as AckError);
             this.remove(message);
           });
         } else {

--- a/src/subscriber.ts
+++ b/src/subscriber.ts
@@ -830,6 +830,7 @@ export class Subscriber extends EventEmitter {
             .catch(() => {
               // Temporary failures will retry, so if an error reaches us
               // here, that means a permanent failure. Silently drop these.
+              this._discardMessage(message);
             });
         } else {
           message.modAck(this.ackDeadline);
@@ -842,6 +843,11 @@ export class Subscriber extends EventEmitter {
         span.end();
       }
     }
+  }
+
+  // Internal: This is here to provide a hook for unit testing, at least for now.
+  private _discardMessage(message: Message): void {
+    message;
   }
 
   /**

--- a/test/subscriber.ts
+++ b/test/subscriber.ts
@@ -1048,6 +1048,27 @@ describe('Subscriber', () => {
         assert.strictEqual(msg, message);
       });
 
+      it('should ack the message with response', async () => {
+        subscriber.subscriptionProperties = {exactlyOnceDeliveryEnabled: true};
+        const stub = sandbox.stub(subscriber, 'ackWithResponse');
+
+        stub.resolves(s.AckResponses.Success);
+        const response = await message.ackWithResponse();
+        assert.strictEqual(response, s.AckResponses.Success);
+      });
+
+      it('should fail to ack the message with response', async () => {
+        subscriber.subscriptionProperties = {exactlyOnceDeliveryEnabled: true};
+        const stub = sandbox.stub(subscriber, 'ackWithResponse');
+
+        stub.rejects(new s.AckError(s.AckResponses.Invalid));
+        await assert.rejects(message.ackWithResponse());
+
+        // Should cache the result also.
+        await assert.rejects(message.ackWithResponse());
+        assert.strictEqual(stub.callCount, 1);
+      });
+
       it('should not ack the message if its been handled', () => {
         const stub = sandbox.stub(subscriber, 'ack');
 
@@ -1070,6 +1091,27 @@ describe('Subscriber', () => {
         assert.strictEqual(deadline, fakeDeadline);
       });
 
+      it('should modAck the message with response', async () => {
+        subscriber.subscriptionProperties = {exactlyOnceDeliveryEnabled: true};
+        const stub = sandbox.stub(subscriber, 'modAckWithResponse');
+
+        stub.resolves(s.AckResponses.Success);
+        const response = await message.modAckWithResponse(0);
+        assert.strictEqual(response, s.AckResponses.Success);
+      });
+
+      it('should fail to modAck the message with response', async () => {
+        subscriber.subscriptionProperties = {exactlyOnceDeliveryEnabled: true};
+        const stub = sandbox.stub(subscriber, 'modAckWithResponse');
+
+        stub.rejects(new s.AckError(s.AckResponses.Invalid));
+        await assert.rejects(message.modAckWithResponse(0));
+
+        // Should cache the result also.
+        await assert.rejects(message.modAckWithResponse(0));
+        assert.strictEqual(stub.callCount, 1);
+      });
+
       it('should not modAck the message if its been handled', () => {
         const deadline = 10;
         const stub = sandbox.stub(subscriber, 'modAck');
@@ -1090,6 +1132,27 @@ describe('Subscriber', () => {
         const [msg, delay] = stub.lastCall.args;
         assert.strictEqual(msg, message);
         assert.strictEqual(delay, 0);
+      });
+
+      it('should nack the message with response', async () => {
+        subscriber.subscriptionProperties = {exactlyOnceDeliveryEnabled: true};
+        const stub = sandbox.stub(subscriber, 'nackWithResponse');
+
+        stub.resolves(s.AckResponses.Success);
+        const response = await message.nackWithResponse();
+        assert.strictEqual(response, s.AckResponses.Success);
+      });
+
+      it('should fail to nack the message with response', async () => {
+        subscriber.subscriptionProperties = {exactlyOnceDeliveryEnabled: true};
+        const stub = sandbox.stub(subscriber, 'nackWithResponse');
+
+        stub.rejects(new s.AckError(s.AckResponses.Invalid));
+        await assert.rejects(message.nackWithResponse());
+
+        // Should cache the result also.
+        await assert.rejects(message.nackWithResponse());
+        assert.strictEqual(stub.callCount, 1);
       });
 
       it('should not nack the message if its been handled', () => {


### PR DESCRIPTION
Two fixes in this one:

- receipt modAcks were not being handled properly in exactly-once delivery mode; they were basically being treated the same as non-EOD receipt modAcks
- the leasing manager was not doing modAckWithResponse when extending leases, which could cause memory and CPU leaks over time for exactly-once delivery subscriptions

I also discovered that we were missing a bunch of unit tests around this stuff, so I added some more.

Fixes https://github.com/googleapis/nodejs-pubsub/issues/1697
