### PR TITLE
fix: avoid zalgo when calling down to publish messages

### DIFF
--- a/src/publisher/message-queues.ts
+++ b/src/publisher/message-queues.ts
@@ -102,7 +102,8 @@ export abstract class MessageQueue extends EventEmitter {
     };
     if (messages.length === 0) {
       if (typeof callback === 'function') {
-        callback(null);
+        // Do this on the next tick to avoid Zalgo with the publish request below.
+        process.nextTick(() => callback(null));
       }
       return;
     }


### PR DESCRIPTION
I just noticed this when looking at other things - the publish() call will almost certainly call the callback async.
