### PR TITLE
feat: rework low level message stream retries, add debugging

### DIFF
--- a/src/debug.ts
+++ b/src/debug.ts
@@ -1,0 +1,33 @@
+// Copyright 2023 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+/**
+ * Represents a debug message the user might want to print out for logging
+ * while debugging or whatnot. These will always come by way of the 'error'
+ * channel on streams or other event emitters. It's completely fine to
+ * ignore them, as some will just be verbose logging info, but they may
+ * help figure out what's going wrong. Support may also ask you to catch
+ * these channels, which you can do like so:
+ *
+ * ```
+ * subscription.on('debug', msg => console.log(msg.message));
+ * ```
+ *
+ * These values are _not_ guaranteed to remain stable, even within a major
+ * version, so don't depend on them for your program logic. Debug outputs
+ * may be added or removed at any time, without warning.
+ */
+export class DebugMessage {
+  constructor(public message: string, public error?: Error) {}
+}

--- a/src/exponential-retry.ts
+++ b/src/exponential-retry.ts
@@ -138,6 +138,17 @@ export class ExponentialRetry<T> {
     this.scheduleRetry();
   }
 
+  /**
+   * Resets an item that was previously retried. This is useful if you have
+   * persistent items that just need to be retried occasionally.
+   *
+   * @private
+   */
+  reset(item: T) {
+    const retried = item as RetriedItem<T>;
+    delete retried.retryInfo;
+  }
+
   // Takes a time delta and adds fuzz.
   private randomizeDelta(durationMs: number): number {
     // The fuzz distance should never exceed one second, but in the

--- a/src/index.ts
+++ b/src/index.ts
@@ -174,6 +174,7 @@ export {
   TopicMetadata,
 } from './topic';
 export {Duration, TotalOfUnit, DurationLike} from './temporal';
+export {DebugMessage} from './debug';
 
 if (process.env.DEBUG_GRPC) {
   console.info('gRPC logging set to verbose');

--- a/src/message-stream.ts
+++ b/src/message-stream.ts
@@ -25,6 +25,7 @@ import {google} from '../protos/protos';
 import {defaultOptions} from './default-options';
 import {Duration} from './temporal';
 import {ExponentialRetry} from './exponential-retry';
+import {DebugMessage} from './debug';
 
 /*!
  * Frequency to ping streams.
@@ -359,7 +360,7 @@ export class MessageStream extends PassThrough {
     if (PullRetry.retry(status)) {
       this.emit(
         'debug',
-        new Error(
+        new DebugMessage(
           `Subscriber stream ${index} has ended with status ${status.code}; will be retried.`
         )
       );
@@ -372,7 +373,7 @@ export class MessageStream extends PassThrough {
     } else if (this._activeStreams() === 0) {
       this.emit(
         'debug',
-        new Error(
+        new DebugMessage(
           `Subscriber stream ${index} has ended with status ${status.code}; will not be retried.`
         )
       );

--- a/src/message-stream.ts
+++ b/src/message-stream.ts
@@ -357,6 +357,12 @@ export class MessageStream extends PassThrough {
     this._removeStream(index);
 
     if (PullRetry.retry(status)) {
+      this.emit(
+        'debug',
+        new Error(
+          `Subscriber stream ${index} has ended with status ${status.code}; will be retried.`
+        )
+      );
       if (PullRetry.resetFailures(status)) {
         this._retrier.reset(this._streams[index]);
       }
@@ -364,6 +370,13 @@ export class MessageStream extends PassThrough {
         this._fillStreamPool();
       });
     } else if (this._activeStreams() === 0) {
+      this.emit(
+        'debug',
+        new Error(
+          `Subscriber stream ${index} has ended with status ${status.code}; will not be retried.`
+        )
+      );
+
       // No streams left, and nothing to retry.
       this.destroy(new StatusError(status));
     }

--- a/src/message-stream.ts
+++ b/src/message-stream.ts
@@ -51,7 +51,7 @@ export interface MessageStreamOptions {
   highWaterMark?: number;
   maxStreams?: number;
   timeout?: number;
-  retryBackoff?: Duration;
+  retryMinBackoff?: Duration;
   retryMaxBackoff?: Duration;
 }
 
@@ -62,7 +62,7 @@ const DEFAULT_OPTIONS: MessageStreamOptions = {
   highWaterMark: 0,
   maxStreams: defaultOptions.subscription.maxStreams,
   timeout: 300000,
-  retryBackoff: Duration.from({millis: 100}),
+  retryMinBackoff: Duration.from({millis: 100}),
   retryMaxBackoff: Duration.from({millis: 5000}),
 };
 
@@ -154,7 +154,7 @@ export class MessageStream extends PassThrough {
 
     this._options = options;
     this._retrier = new ExponentialRetry<{}>(
-      options.retryBackoff!, // Filled by DEFAULT_OPTIONS
+      options.retryMinBackoff!, // Filled by DEFAULT_OPTIONS
       options.retryMaxBackoff!
     );
 

--- a/src/message-stream.ts
+++ b/src/message-stream.ts
@@ -63,7 +63,7 @@ const DEFAULT_OPTIONS: MessageStreamOptions = {
   maxStreams: defaultOptions.subscription.maxStreams,
   timeout: 300000,
   retryMinBackoff: Duration.from({millis: 100}),
-  retryMaxBackoff: Duration.from({millis: 5000}),
+  retryMaxBackoff: Duration.from({seconds: 60}),
 };
 
 interface StreamState {

--- a/src/subscriber.ts
+++ b/src/subscriber.ts
@@ -685,6 +685,11 @@ export class Subscriber extends EventEmitter {
       .on('full', () => this._stream.pause())
       .on('free', () => this._stream.resume());
 
+    this._stream.start().catch(err => {
+      this.emit('error', err);
+      this.close();
+    });
+
     this.isOpen = true;
   }
 

--- a/src/subscriber.ts
+++ b/src/subscriber.ts
@@ -677,7 +677,7 @@ export class Subscriber extends EventEmitter {
 
     this._stream
       .on('error', err => this.emit('error', err))
-      .on('debug', err => this.emit('debug', err))
+      .on('debug', msg => this.emit('debug', msg))
       .on('data', (data: PullResponse) => this._onData(data))
       .once('close', () => this.close());
 

--- a/src/subscription.ts
+++ b/src/subscription.ts
@@ -106,7 +106,7 @@ export type DetachSubscriptionResponse = EmptyResponse;
     listener: (error: StatusError) => void
   ): this;
   on(event: 'close', listener: () => void): this;
-  on(event: 'debug', listener: (error: StatusError) => void); this;
+  on(event: 'debug', listener: (msg: DebugMessage) => void); this;
 
   // Only used internally.
   on(event: 'newListener', listener: Function): this;
@@ -158,7 +158,7 @@ export type DetachSubscriptionResponse = EmptyResponse;
  * on(event: 'error', listener: (error: Error) => void): this;
  *
  * Upon receipt of a (non-fatal) debug warning:
- * on(event: 'debug', listener: (error: Error) => void): this;
+ * on(event: 'debug', listener: (msg: DebugMessage) => void): this;
  *
  * Upon the closing of the subscriber:
  * on(event: 'close', listener: Function): this;
@@ -226,8 +226,8 @@ export type DetachSubscriptionResponse = EmptyResponse;
  * // Register an error handler.
  * subscription.on('error', (err) => {});
  *
- * // Register a debug handler, to catch non-fatal errors.
- * subscription.on('debug', (err) => { console.error(err); });
+ * // Register a debug handler, to catch non-fatal errors and other messages.
+ * subscription.on('debug', msg => { console.log(msg.message); });
  *
  * // Register a close handler in case the subscriber closes unexpectedly
  * subscription.on('close', () => {});
@@ -327,7 +327,7 @@ export class Subscription extends EventEmitter {
     this._subscriber = new Subscriber(this, options);
     this._subscriber
       .on('error', err => this.emit('error', err))
-      .on('debug', err => this.emit('debug', err))
+      .on('debug', msg => this.emit('debug', msg))
       .on('message', message => this.emit('message', message))
       .on('close', () => this.emit('close'));
 

--- a/test/subscriber.ts
+++ b/test/subscriber.ts
@@ -135,6 +135,7 @@ class FakeMessageStream extends PassThrough {
     // eslint-disable-next-line @typescript-eslint/no-unused-vars
     _callback: (error: Error | null) => void
   ): void {}
+  async start() {}
 }
 
 class FakePreciseDate {

--- a/test/subscription.ts
+++ b/test/subscription.ts
@@ -24,6 +24,7 @@ import {Snapshot} from '../src/snapshot';
 import {Message, SubscriberOptions} from '../src/subscriber';
 import * as subby from '../src/subscription';
 import * as util from '../src/util';
+import {DebugMessage} from '../src/debug';
 
 let promisified = false;
 const fakeUtil = Object.assign({}, util, {
@@ -511,6 +512,7 @@ describe('Subscription', () => {
 
   describe('debug', () => {
     const error = new Error('err') as ServiceError;
+    const msg = new DebugMessage(error.message, error);
 
     beforeEach(() => {
       subscription.request = (config, callback) => {
@@ -519,12 +521,12 @@ describe('Subscription', () => {
     });
 
     it('should return the debug events to the callback', done => {
-      subscription.on?.('debug', err => {
-        assert.strictEqual(err, error);
+      subscription.on?.('debug', (msg: DebugMessage) => {
+        assert.strictEqual(msg.error, error);
         done();
       });
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      (subscription as any)._subscriber.emit('debug', error);
+      (subscription as any)._subscriber.emit('debug', msg);
     });
   });
 


### PR DESCRIPTION
Adjusts stream retries to standard exponential backoff behaviour, adds a few knobs for tweaking the settings of the backoff, and adds some 'debug' events on the subscription object for seeing when disconnects and reconnects happen.

Fixes #1712 