### PR TITLE
chore: pull promise-based publish out of OTel change

### DIFF
--- a/src/publisher/index.ts
+++ b/src/publisher/index.ts
@@ -123,14 +123,12 @@ export class Publisher {
               // event listeners after we've completed flush().
               q.removeListener('drain', flushResolver);
             };
-            return q.on('drain', flushResolver);
+            q.on('drain', flushResolver);
           })
       )
     );
 
-    const allPublishes = Promise.all(
-      toDrain.map(q => promisify(q.publishDrain).bind(q)())
-    );
+    const allPublishes = Promise.all(toDrain.map(q => q.publishDrain()));
 
     allPublishes
       .then(() => allDrains)
@@ -139,6 +137,7 @@ export class Publisher {
       })
       .catch(definedCallback);
   }
+
   /**
    * Publish the provided message.
    *

--- a/src/publisher/index.ts
+++ b/src/publisher/index.ts
@@ -14,7 +14,6 @@
  * limitations under the License.
  */
 
-import {promisify} from '@google-cloud/promisify';
 import * as extend from 'extend';
 import {CallOptions} from 'google-gax';
 import {SemanticAttributes} from '@opentelemetry/semantic-conventions';

--- a/src/publisher/message-queues.ts
+++ b/src/publisher/message-queues.ts
@@ -152,19 +152,23 @@ export class Queue extends MessageQueue {
    */
   add(message: PubsubMessage, callback: PublishCallback): void {
     if (!this.batch.canFit(message)) {
-      // Ignore errors.
+      // Make a background best-effort attempt to clear out the
+      // queue. If this fails, we'll basically just be overloaded
+      // for a bit.
       this.publish().catch(() => {});
     }
 
     this.batch.add(message, callback);
 
     if (this.batch.isFull()) {
-      // Ignore errors.
+      // See comment above - best effort.
       this.publish().catch(() => {});
     } else if (!this.pending) {
       const {maxMilliseconds} = this.batchOptions;
       this.pending = setTimeout(() => {
-        // Ignore errors.
+        // See comment above - we are basically making a best effort
+        // to start clearing out the queue if nothing else happens
+        // before the batch timeout.
         this.publish().catch(() => {});
       }, maxMilliseconds!);
     }
@@ -282,7 +286,9 @@ export class OrderedQueue extends MessageQueue {
     }
 
     if (!this.currentBatch.canFit(message)) {
-      // Ignore errors.
+      // Make a best-effort attempt to clear out the publish queue,
+      // to make more space for the new batch. If this fails, we'll
+      // just be overfilled for a bit.
       this.publish().catch(() => {});
     }
 
@@ -292,7 +298,7 @@ export class OrderedQueue extends MessageQueue {
     // check again here
     if (!this.inFlight) {
       if (this.currentBatch.isFull()) {
-        // Ignore errors.
+        // See comment above - best-effort.
         this.publish().catch(() => {});
       } else if (!this.pending) {
         this.beginNextPublish();
@@ -308,7 +314,9 @@ export class OrderedQueue extends MessageQueue {
     const delay = Math.max(0, maxMilliseconds - timeWaiting);
 
     this.pending = setTimeout(() => {
-      // Ignore errors.
+      // Make a best-effort attempt to start a publish request. If
+      // this fails, we'll catch it again later, eventually, when more
+      // messages try to enter the queue.
       this.publish().catch(() => {});
     }, delay);
   }

--- a/test/publisher/message-queues.ts
+++ b/test/publisher/message-queues.ts
@@ -169,42 +169,41 @@ describe('Message Queues', () => {
         assert.strictEqual(gaxOpts, callOptions);
       });
 
-      it('should pass back any request errors', done => {
+      it('should pass back any request errors', async () => {
         const error = new Error('err') as ServiceError;
 
         sandbox.stub(topic, 'request').callsFake((config, callback) => {
           callback(error);
         });
 
-        queue._publish(messages, callbacks, err => {
+        try {
+          await queue._publish(messages, callbacks);
+          assert.strictEqual(null, error, '_publish did not throw');
+        } catch (e) {
+          const err = e as ServiceError;
+
           assert.strictEqual(err, error);
 
           callbacks.forEach(callback => {
             const [err] = callback.lastCall.args;
             assert.strictEqual(err, error);
           });
-
-          done();
-        });
+        }
       });
 
-      it('should pass back message ids', done => {
+      it('should pass back message ids', async () => {
         const messageIds = messages.map((_, i) => `message${i}`);
 
         sandbox.stub(topic, 'request').callsFake((config, callback) => {
           callback(null, {messageIds});
         });
 
-        queue._publish(messages, callbacks, err => {
-          assert.ifError(err);
+        await queue._publish(messages, callbacks);
 
-          callbacks.forEach((callback, i) => {
-            const [, messageId] = callback.lastCall.args;
-            const expectedId = `message${i}`;
-            assert.strictEqual(messageId, expectedId);
-          });
-
-          done();
+        callbacks.forEach((callback, i) => {
+          const [, messageId] = callback.lastCall.args;
+          const expectedId = `message${i}`;
+          assert.strictEqual(messageId, expectedId);
         });
       });
     });
@@ -241,20 +240,19 @@ describe('Message Queues', () => {
         const addStub = sandbox.stub(queue.batch, 'add');
         sandbox.stub(queue.batch, 'canFit').returns(false);
 
-        sandbox
-          .stub(queue, 'publish')
-          .onCall(0)
-          .callsFake(() => {
-            assert.strictEqual(addStub.callCount, 0);
-            done();
-          });
+        const publishStub = sandbox.stub(queue, 'publish');
+        publishStub.onCall(0).callsFake(async () => {
+          assert.strictEqual(addStub.callCount, 0);
+          done();
+        });
+        publishStub.resolves();
 
         queue.add(fakeMessage, spy);
       });
 
       it('should add the message to the batch', () => {
         const stub = sandbox.stub(queue.batch, 'add');
-        sandbox.stub(queue, 'publish');
+        sandbox.stub(queue, 'publish').resolves();
 
         queue.add(fakeMessage, spy);
 
@@ -264,7 +262,7 @@ describe('Message Queues', () => {
       });
 
       it('should publish immediately if the batch became full', () => {
-        const stub = sandbox.stub(queue, 'publish');
+        const stub = sandbox.stub(queue, 'publish').resolves();
         sandbox.stub(queue.batch, 'isFull').returns(true);
 
         queue.add(fakeMessage, spy);
@@ -274,7 +272,7 @@ describe('Message Queues', () => {
 
       it('should set a timeout to publish if need be', () => {
         const clock = sandbox.useFakeTimers();
-        const stub = sandbox.stub(queue, 'publish');
+        const stub = sandbox.stub(queue, 'publish').resolves();
         const maxMilliseconds = 1234;
 
         queue.batchOptions = {maxMilliseconds};
@@ -288,7 +286,7 @@ describe('Message Queues', () => {
 
       it('should noop if a timeout is already set', () => {
         const clock = sandbox.useFakeTimers();
-        const stub = sandbox.stub(queue, 'publish');
+        const stub = sandbox.stub(queue, 'publish').resolves();
         const maxMilliseconds = 1234;
 
         queue.batchOptions = {maxMilliseconds};
@@ -343,10 +341,10 @@ describe('Message Queues', () => {
           spies = [sandbox.spy(), sandbox.spy()] as p.PublishCallback[];
         });
 
-        it('should begin another publish(drain) if there are pending batches', () => {
+        it('should begin another publish(drain) if there are pending batches', done => {
           const stub = sandbox.stub(queue, '_publish');
           let once = false;
-          stub.callsFake((m, c, done) => {
+          stub.callsFake(async () => {
             if (!once) {
               // Drop in a second batch before calling the callback.
               const secondBatch = new FakeMessageBatch();
@@ -355,22 +353,23 @@ describe('Message Queues', () => {
               queue.batch = secondBatch;
             }
             once = true;
-
-            done!(null);
           });
 
           queue.batch = new FakeMessageBatch();
           queue.batch.messages = fakeMessages;
           queue.batch.callbacks = spies;
-          queue.publishDrain();
-
-          assert.strictEqual(stub.callCount, 2);
+          queue.publishDrain().then(() => {
+            process.nextTick(() => {
+              assert.strictEqual(stub.callCount, 2);
+              done();
+            });
+          });
         });
 
         it('should not begin another publish(non-drain) if there are pending batches', () => {
           const stub = sandbox.stub(queue, '_publish');
           let once = false;
-          stub.callsFake((m, c, done) => {
+          stub.callsFake(async () => {
             if (!once) {
               // Drop in a second batch before calling the callback.
               const secondBatch = new FakeMessageBatch();
@@ -379,28 +378,27 @@ describe('Message Queues', () => {
               queue.batch = secondBatch;
             }
             once = true;
-
-            done!(null);
           });
 
           queue.batch = new FakeMessageBatch();
           queue.batch.messages = fakeMessages;
           queue.batch.callbacks = spies;
-          queue.publish();
-
-          assert.strictEqual(stub.callCount, 1);
+          queue.publish().then(() => {
+            assert.strictEqual(stub.callCount, 1);
+          });
         });
 
-        it('should emit "drain" if there is nothing left to publish', () => {
+        it('should emit "drain" if there is nothing left to publish', done => {
           const spy = sandbox.spy();
-          sandbox
-            .stub(queue, '_publish')
-            .callsFake((m, c, done) => done!(null));
+          sandbox.stub(queue, '_publish').callsFake(async () => {});
 
           queue.on('drain', spy);
-          queue.publish();
-
-          assert.strictEqual(spy.callCount, 1);
+          queue.publish().then(() => {
+            process.nextTick(() => {
+              assert.strictEqual(spy.callCount, 1);
+              done();
+            });
+          });
         });
       });
     });
@@ -506,13 +504,12 @@ describe('Message Queues', () => {
           const addStub = sandbox.stub(batch, 'add');
 
           sandbox.stub(batch, 'canFit').withArgs(fakeMessage).returns(false);
-          sandbox
-            .stub(queue, 'publish')
-            .onCall(0)
-            .callsFake(() => {
-              assert.strictEqual(addStub.callCount, 0);
-              done();
-            });
+          const publishStub = sandbox.stub(queue, 'publish');
+          publishStub.onCall(0).callsFake(async () => {
+            assert.strictEqual(addStub.callCount, 0);
+            done();
+          });
+          publishStub.resolves();
 
           queue.add(fakeMessage, spy);
         });
@@ -528,12 +525,12 @@ describe('Message Queues', () => {
         });
 
         it('should noop after adding if a publish was triggered', () => {
-          const publishStub = sandbox.stub(queue, 'publish');
+          const publishStub = sandbox.stub(queue, 'publish').resolves();
           const beginPublishStub = sandbox.stub(queue, 'beginNextPublish');
 
           sandbox.stub(batch, 'canFit').returns(false);
 
-          publishStub.onCall(0).callsFake(() => {
+          publishStub.onCall(0).callsFake(async () => {
             queue.inFlight = true;
           });
 
@@ -544,7 +541,7 @@ describe('Message Queues', () => {
         });
 
         it('should publish immediately if the batch is full', () => {
-          const stub = sandbox.stub(queue, 'publish');
+          const stub = sandbox.stub(queue, 'publish').resolves();
 
           sandbox.stub(batch, 'isFull').returns(true);
           queue.add(fakeMessage, spy);
@@ -585,14 +582,14 @@ describe('Message Queues', () => {
       });
 
       it('should set a timeout that will call publish', done => {
-        sandbox.stub(queue, 'publish').callsFake(done);
+        sandbox.stub(queue, 'publish').callsFake(async () => done());
         queue.beginNextPublish();
         clock.tick(maxMilliseconds);
       });
 
       it('should factor in the time the batch has been sitting', done => {
         const halfway = maxMilliseconds / 2;
-        sandbox.stub(queue, 'publish').callsFake(done);
+        sandbox.stub(queue, 'publish').callsFake(async () => done());
         queue.currentBatch.created = Date.now() - halfway;
         queue.beginNextPublish();
         clock.tick(halfway);
@@ -689,46 +686,46 @@ describe('Message Queues', () => {
         assert.strictEqual(callbacks, spies);
       });
 
-      it('should set inFlight to false after publishing', () => {
-        sandbox.stub(queue, '_publish').callsFake((m, c, done) => done!(null));
+      it('should set inFlight to false after publishing', async () => {
+        sandbox.stub(queue, '_publish').resolves();
 
-        queue.publish();
+        await queue.publish();
 
         assert.strictEqual(queue.inFlight, false);
       });
 
-      it('should handle any publish failures', () => {
+      it('should handle any publish failures', async () => {
         const error = new Error('err') as ServiceError;
         const stub = sandbox.stub(queue, 'handlePublishFailure');
 
-        sandbox.stub(queue, '_publish').callsFake((m, c, done) => done!(error));
+        sandbox.stub(queue, '_publish').rejects(error);
 
-        queue.publish();
+        await queue.publish();
 
         const [err] = stub.lastCall.args;
         assert.strictEqual(err, error);
       });
 
-      it('should begin another publish if there are pending batches', () => {
+      it('should begin another publish if there are pending batches', async () => {
         const stub = sandbox.stub(queue, 'beginNextPublish');
-        sandbox.stub(queue, '_publish').callsFake((m, c, done) => done!(null));
+        sandbox.stub(queue, '_publish').resolves();
 
         const secondBatch = new FakeMessageBatch();
         secondBatch.messages = fakeMessages;
         secondBatch.callbacks = spies;
 
         queue.batches.push(secondBatch as b.MessageBatch);
-        queue.publish();
+        await queue.publish();
 
         assert.strictEqual(stub.callCount, 1);
       });
 
-      it('should emit "drain" if there is nothing left to publish', () => {
+      it('should emit "drain" if there is nothing left to publish', async () => {
         const spy = sandbox.spy();
-        sandbox.stub(queue, '_publish').callsFake((m, c, done) => done!(null));
+        sandbox.stub(queue, '_publish').resolves();
 
         queue.on('drain', spy);
-        queue.publish();
+        await queue.publish();
 
         assert.strictEqual(spy.callCount, 1);
       });


### PR DESCRIPTION
This shifts the publisher to use Promise-based logic instead of callbacks. This was pulled out of the OpenTelemetry change to make that one simpler.
