### PR TITLE
fix: allow updating stream count after opening

### DIFF
--- a/src/subscriber.ts
+++ b/src/subscriber.ts
@@ -776,6 +776,11 @@ export class Subscriber extends EventEmitter {
         this.maxMessages
       );
     }
+
+    // Update our stream wrapper if it's already been opened.
+    if (this._stream && options.streamingOptions) {
+      this._stream.setOptions(options.streamingOptions);
+    }
   }
 
   /**

--- a/test/message-stream.ts
+++ b/test/message-stream.ts
@@ -278,6 +278,79 @@ describe('MessageStream', () => {
           await promisify(process.nextTick)();
           assert.strictEqual(client.deadline, now + timeout);
         });
+
+        it('should update from new options before starting', async () => {
+          const timeout = 12345;
+          const maxStreams = 10;
+
+          messageStream = new MessageStream(subscriber, {
+            timeout: 0,
+            maxStreams: 5,
+          });
+          messageStream.setOptions({
+            timeout,
+            maxStreams,
+          });
+          await messageStream.start();
+
+          await promisify(process.nextTick)();
+          assert.strictEqual(client.deadline, now + timeout);
+          assert.strictEqual(client.streams.length, maxStreams);
+        });
+
+        it('should update from new options after starting (decrease)', async () => {
+          const timeout = 12345;
+          const maxStreams = 2;
+
+          messageStream = new MessageStream(subscriber, {
+            timeout: 0,
+            maxStreams: 5,
+          });
+          messageStream.setOptions({
+            timeout,
+            maxStreams,
+          });
+          await messageStream.start();
+
+          await promisify(process.nextTick)();
+
+          messageStream.setOptions({
+            timeout,
+            maxStreams,
+          });
+
+          await promisify(process.nextTick)();
+
+          assert.strictEqual(client.deadline, now + timeout);
+          assert.strictEqual(client.streams.length, maxStreams);
+        });
+
+        it('should update from new options after starting (decrease)', async () => {
+          const timeout = 12345;
+          const maxStreams = 10;
+
+          messageStream = new MessageStream(subscriber, {
+            timeout: 0,
+            maxStreams: 5,
+          });
+          messageStream.setOptions({
+            timeout,
+            maxStreams,
+          });
+          await messageStream.start();
+
+          await promisify(process.nextTick)();
+
+          messageStream.setOptions({
+            timeout,
+            maxStreams,
+          });
+
+          await promisify(process.nextTick)();
+
+          assert.strictEqual(client.deadline, now + timeout);
+          assert.strictEqual(client.streams.length, maxStreams);
+        });
       });
     });
   });

--- a/test/subscriber.ts
+++ b/test/subscriber.ts
@@ -133,6 +133,7 @@ class FakeMessageStream extends PassThrough {
     this.options = options;
     stubs.set('messageStream', this);
   }
+  setOptions(): void {}
   setStreamAckDeadline(): void {}
   _destroy(
     // eslint-disable-next-line @typescript-eslint/no-unused-vars


### PR DESCRIPTION
Fixes: https://github.com/googleapis/nodejs-pubsub/issues/1722

I recognize that the unit tests for ExponentialRetry dig into it too much, but I don't really want to redo them in this context.
