### PR TITLE
tests: add schema cleanup

### DIFF
--- a/samples/system-test/testResources.ts
+++ b/samples/system-test/testResources.ts
@@ -147,16 +147,19 @@ export class TestResources {
   filterForCleanup(allResources: Resource[]): Resource[] {
     const currentRunPrefix = this.getPrefix();
     return allResources.filter(n => {
-      const name = n.name || null;
-      if (name === null) {
+      let name = n.name || undefined;
+      if (name === undefined) {
         return false;
       }
 
-      if (name.includes(currentRunPrefix)) {
+      // We'll always get at least one thing.
+      name = name.split('/').pop()!;
+
+      if (name.startsWith(currentRunPrefix)) {
         return true;
       }
 
-      if (name.includes(this.testSuiteId)) {
+      if (name.startsWith(this.testSuiteId)) {
         const parts = name.split('-');
         const createdAt = Number(parts[1]);
         const timeDiff = (Date.now() - createdAt) / (1000 * 60 * 60);

--- a/system-test/pubsub.ts
+++ b/system-test/pubsub.ts
@@ -104,14 +104,14 @@ describe('pubsub', () => {
     }
 
     const createdAt = Number(resource.name.split('-').pop());
-    const timeDiff = (Date.now() - createdAt) / (1000 * 60 * 60);
+    const timeDiff = (Date.now() - createdAt) / (2 * 1000 * 60 * 60);
 
     if (timeDiff > 1) {
       resource.delete();
     }
   }
 
-  async function deleteTestResources(): Promise<Resource[]> {
+  async function deleteTestResources(): Promise<void> {
     const topicStream = pubsub.getTopicsStream().on('data', deleteTestResource);
     const subscriptionStream = pubsub
       .getSubscriptionsStream()
@@ -129,7 +129,36 @@ describe('pubsub', () => {
       }
     );
 
-    return Promise.all(streams);
+    // Schemas might be dependencies on topics, so wait for these first.
+    await Promise.all(streams);
+
+    const allSchemas: Promise<void>[] = [];
+    for await (const s of pubsub.listSchemas()) {
+      let deleteSchema = false;
+      const name = s.name;
+      if (!name) {
+        continue;
+      }
+
+      // Delete resource from current test run.
+      if (name.includes(CURRENT_TIME.toString())) {
+        deleteSchema = true;
+      } else if (name.includes(PREFIX)) {
+        // Delete left over resources which are older then 1 hour.
+        const createdAt = Number(s.name?.split('-').pop());
+        const timeDiff = (Date.now() - createdAt) / (2 * 1000 * 60 * 60);
+
+        if (timeDiff > 1) {
+          deleteSchema = true;
+        }
+      }
+
+      if (deleteSchema) {
+        const wrapped = pubsub.schema(name);
+        allSchemas.push(wrapped.delete());
+      }
+    }
+    await Promise.all(allSchemas);
   }
 
   async function publishPop(message: MessageOptions) {

--- a/test/pubsub.ts
+++ b/test/pubsub.ts
@@ -27,8 +27,7 @@ import {Snapshot} from '../src/snapshot';
 import * as subby from '../src/subscription';
 import {Topic} from '../src/topic';
 import * as util from '../src/util';
-import {Schema, SchemaTypes} from '../src';
-import {ISchema, SchemaViews} from '../src/schema';
+import {Schema, SchemaTypes, ISchema, SchemaViews} from '../src/schema';
 // eslint-disable-next-line @typescript-eslint/no-var-requires
 const PKG = require('../../package.json');
 const sandbox = sinon.createSandbox();


### PR DESCRIPTION
Schemas were not being cleaned up properly, resulting in quota issues in the test projects on GCP. This fixes that and syncs up the "max old time" for resources to be deleted even if they're not part of the current run.

Fixes: https://github.com/googleapis/nodejs-pubsub/issues/1765 🧐
