### PR TITLE
feat!: node 12 deprecation

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node: [12, 14, 16]
+        node: [14, 16, 18, 20]
     steps:
       - uses: actions/checkout@v3
       - uses: actions/setup-node@v3

--- a/package.json
+++ b/package.json
@@ -58,7 +58,7 @@
     "arrify": "^2.0.0",
     "extend": "^3.0.2",
     "google-auth-library": "^8.0.2",
-    "google-gax": "^3.5.6",
+    "google-gax": "next",
     "heap-js": "^2.2.0",
     "is-stream-ended": "^0.1.4",
     "lodash.snakecase": "^4.1.1",

--- a/src/subscription.ts
+++ b/src/subscription.ts
@@ -42,9 +42,11 @@ import {
   SeekResponse,
   Snapshot,
 } from './snapshot';
-import {Subscriber, SubscriberOptions} from './subscriber';
+import {Message, Subscriber, SubscriberOptions} from './subscriber';
 import {Topic} from './topic';
 import {promisifySome} from './util';
+import {StatusError} from './message-stream';
+import {DebugMessage} from './debug';
 
 export {AckError, AckResponse, AckResponses} from './subscriber';
 
@@ -92,30 +94,26 @@ export type DetachSubscriptionResponse = EmptyResponse;
 
 // JSDoc won't see these, so this is just to let you get typings
 // in your editor of choice.
-//
-// NOTE: These are commented out for now because we don't want to
-// break any existing clients that rely on not-entirely-correct
-// typings. We'll re-enable on the next major.
-/* export declare interface Subscription {
-  on(
-    event: 'message',
-    listener: (message: Message) => void
-  ): this;
-  on(
-    event: 'error',
-    listener: (error: StatusError) => void
-  ): this;
+export declare interface Subscription {
+  on(event: 'message', listener: (message: Message) => void): this;
+  on(event: 'error', listener: (error: StatusError) => void): this;
   on(event: 'close', listener: () => void): this;
-  on(event: 'debug', listener: (msg: DebugMessage) => void); this;
+  on(event: 'debug', listener: (msg: DebugMessage) => void): this;
 
   // Only used internally.
-  on(event: 'newListener', listener: Function): this;
-  on(event: 'removeListener', listener: Function): this;
+  on(
+    event: 'newListener',
+    listener: (event: string | symbol, listener: Function) => void
+  ): this;
+  on(
+    event: 'removeListener',
+    listener: (event: string | symbol, listener: Function) => void
+  ): this;
 
   // Catch-all. If you get an error about this line, it means you're
   // using an unsupported event type or listener type.
   on(event: string, listener: void): this;
-} */
+}
 
 /**
  * @typedef {object} ExpirationPolicy

--- a/src/v1/publisher_client.ts
+++ b/src/v1/publisher_client.ts
@@ -1546,7 +1546,7 @@ export class PublisherClient {
       IamProtos.google.iam.v1.GetIamPolicyRequest | null | undefined,
       {} | null | undefined
     >
-  ): Promise<IamProtos.google.iam.v1.Policy> {
+  ): Promise<[IamProtos.google.iam.v1.Policy]> {
     return this.iamClient.getIamPolicy(request, options, callback);
   }
 
@@ -1594,7 +1594,7 @@ export class PublisherClient {
       IamProtos.google.iam.v1.SetIamPolicyRequest | null | undefined,
       {} | null | undefined
     >
-  ): Promise<IamProtos.google.iam.v1.Policy> {
+  ): Promise<[IamProtos.google.iam.v1.Policy]> {
     return this.iamClient.setIamPolicy(request, options, callback);
   }
 

--- a/src/v1/schema_service_client.ts
+++ b/src/v1/schema_service_client.ts
@@ -1494,7 +1494,7 @@ export class SchemaServiceClient {
       IamProtos.google.iam.v1.GetIamPolicyRequest | null | undefined,
       {} | null | undefined
     >
-  ): Promise<IamProtos.google.iam.v1.Policy> {
+  ): Promise<[IamProtos.google.iam.v1.Policy]> {
     return this.iamClient.getIamPolicy(request, options, callback);
   }
 
@@ -1542,7 +1542,7 @@ export class SchemaServiceClient {
       IamProtos.google.iam.v1.SetIamPolicyRequest | null | undefined,
       {} | null | undefined
     >
-  ): Promise<IamProtos.google.iam.v1.Policy> {
+  ): Promise<[IamProtos.google.iam.v1.Policy]> {
     return this.iamClient.setIamPolicy(request, options, callback);
   }
 

--- a/src/v1/subscriber_client.ts
+++ b/src/v1/subscriber_client.ts
@@ -2159,7 +2159,7 @@ export class SubscriberClient {
       IamProtos.google.iam.v1.GetIamPolicyRequest | null | undefined,
       {} | null | undefined
     >
-  ): Promise<IamProtos.google.iam.v1.Policy> {
+  ): Promise<[IamProtos.google.iam.v1.Policy]> {
     return this.iamClient.getIamPolicy(request, options, callback);
   }
 
@@ -2207,7 +2207,7 @@ export class SubscriberClient {
       IamProtos.google.iam.v1.SetIamPolicyRequest | null | undefined,
       {} | null | undefined
     >
-  ): Promise<IamProtos.google.iam.v1.Policy> {
+  ): Promise<[IamProtos.google.iam.v1.Policy]> {
     return this.iamClient.setIamPolicy(request, options, callback);
   }
 


### PR DESCRIPTION
This is currently just a placeholder PR for efforts to push out a new major that drops Node 12 support and pulls in a couple of minor breaking changes for typings, and a new gax.
