### PR TITLE
fix: update to gax 3.6.1 for vuln fix

### DIFF
--- a/package.json
+++ b/package.json
@@ -58,7 +58,7 @@
     "arrify": "^2.0.0",
     "extend": "^3.0.2",
     "google-auth-library": "^8.0.2",
-    "google-gax": "^3.5.6",
+    "google-gax": "^3.6.1",
     "heap-js": "^2.2.0",
     "is-stream-ended": "^0.1.4",
     "lodash.snakecase": "^4.1.1",


### PR DESCRIPTION
Fixes https://github.com/googleapis/nodejs-pubsub/issues/1773