### PR TITLE
build: add legacy v3 branch to release-please config

### DIFF
--- a/.github/release-please.yml
+++ b/.github/release-please.yml
@@ -4,3 +4,7 @@ branches:
 - branch: legacy-v2
   releaseType: node
   handleGHRelease: true
+- branch: legacy-v3
+  releaseType: node
+  handleGHRelease: true
+


### PR DESCRIPTION
This is to get 3.x branch releases going.
