### PR TITLE
fix: set grpc keepalive time|outs by default

### DIFF
--- a/src/pubsub.ts
+++ b/src/pubsub.ts
@@ -272,16 +272,16 @@ export class PubSub {
   private schemaClient?: SchemaServiceClient;
 
   constructor(options?: ClientConfig) {
-    options = Object.assign({}, options || {});
-
-    // Needed for potentially large responses that may come from using exactly-once delivery.
-    // This will get passed down to grpc client objects.
-    const maxMetadataSize = 'grpc.max_metadata_size';
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    const optionsAny = options as any;
-    if (optionsAny[maxMetadataSize] === undefined) {
-      optionsAny[maxMetadataSize] = 4 * 1024 * 1024; // 4 MiB
-    }
+    // Needed for potentially large responses that may come from using exactly-once delivery,
+    // as well as trying to work around silent connection failures.
+    //
+    // These will get passed down to grpc client objects. User values will overwrite these.
+    const grpcDefaults = {
+      'grpc.max_metadata_size': 4 * 1024 * 1024, // 4 MiB
+      'grpc.keepalive_time_ms': 300000, // 5 minutes
+      'grpc.keepalive_timeout_ms': 20000, // 20 seconds
+    };
+    options = Object.assign(grpcDefaults, options || {});
 
     // Determine what scopes are needed.
     // It is the union of the scopes on both clients.

--- a/test/pubsub.ts
+++ b/test/pubsub.ts
@@ -191,11 +191,16 @@ describe('PubSub', () => {
 
   describe('instantiation', () => {
     const maxMetadataSizeKey = 'grpc.max_metadata_size';
+    const keepaliveTimeKey = 'grpc.keepalive_time_ms';
+    const keepaliveTimeoutKey = 'grpc.keepalive_timeout_ms';
+
     const DEFAULT_OPTIONS = {
       libName: 'gccl',
       libVersion: PKG.version,
       scopes: [],
       [maxMetadataSizeKey]: 4 * 1024 * 1024,
+      [keepaliveTimeKey]: 300000,
+      [keepaliveTimeoutKey]: 20000,
     };
 
     it('should extend the correct methods', () => {
@@ -216,18 +221,24 @@ describe('PubSub', () => {
       assert(new PubSub() instanceof PubSub);
     });
 
-    it('should augment the gRPC options for metadata size', () => {
+    it('should augment the gRPC options', () => {
       let pubsub = new PubSub();
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
       let optionsAny: any = pubsub.options;
       assert.strictEqual(optionsAny[maxMetadataSizeKey], 4 * 1024 * 1024);
+      assert.strictEqual(optionsAny[keepaliveTimeKey], 300000);
+      assert.strictEqual(optionsAny[keepaliveTimeoutKey], 20000);
 
       optionsAny = {
         [maxMetadataSizeKey]: 1 * 1024 * 1024,
+        [keepaliveTimeKey]: 30,
+        [keepaliveTimeoutKey]: 100,
       };
       pubsub = new PubSub(optionsAny);
       optionsAny = pubsub.options;
       assert.strictEqual(optionsAny[maxMetadataSizeKey], 1 * 1024 * 1024);
+      assert.strictEqual(optionsAny[keepaliveTimeKey], 30);
+      assert.strictEqual(optionsAny[keepaliveTimeoutKey], 100);
     });
 
     it('should combine all required scopes', () => {


### PR DESCRIPTION
This turns on grpc keepalives by default. We think this may fix quite a few (sometimes silent) timeout issues, because there's an issue deeper down in the stack that can result in the client library not realizing that its connection has been lost.
