### PR TITLE
build: update @opentelemetry/api version

### DIFF
--- a/package.json
+++ b/package.json
@@ -51,7 +51,7 @@
     "@google-cloud/precise-date": "^3.0.0",
     "@google-cloud/projectify": "^3.0.0",
     "@google-cloud/promisify": "^2.0.0",
-    "@opentelemetry/api": "^1.0.0",
+    "@opentelemetry/api": "^1.6.0",
     "@opentelemetry/semantic-conventions": "~1.3.0",
     "@types/duplexify": "^3.6.0",
     "@types/long": "^4.0.0",


### PR DESCRIPTION
Looks like 1.5.0 was bad and got pulled.