### PR TITLE
fix: bump the minimum gax up to 4.0.4 to get grpc-js fixes

### DIFF
--- a/package.json
+++ b/package.json
@@ -58,7 +58,7 @@
     "arrify": "^2.0.0",
     "extend": "^3.0.2",
     "google-auth-library": "^9.0.0",
-    "google-gax": "^4.0.2",
+    "google-gax": "^4.0.4",
     "heap-js": "^2.2.0",
     "is-stream-ended": "^0.1.4",
     "lodash.snakecase": "^4.1.1",


### PR DESCRIPTION
This is to help deal with the slew of timeout issues we've been seeing.
