### PR TITLE
chore: update for new Node typings

### DIFF
--- a/src/lease-manager.ts
+++ b/src/lease-manager.ts
@@ -64,7 +64,7 @@ export class LeaseManager extends EventEmitter {
   private _options!: FlowControlOptions;
   private _pending: Message[];
   private _subscriber: Subscriber;
-  private _timer?: NodeJS.Timer;
+  private _timer?: NodeJS.Timeout;
   constructor(sub: Subscriber, options = {}) {
     super();
 

--- a/src/message-queues.ts
+++ b/src/message-queues.ts
@@ -112,7 +112,7 @@ export abstract class MessageQueue {
   protected _options!: BatchOptions;
   protected _requests: QueuedMessages;
   protected _subscriber: Subscriber;
-  protected _timer?: NodeJS.Timer;
+  protected _timer?: NodeJS.Timeout;
   protected _retrier: ExponentialRetry<QueuedMessage>;
   protected _closed = false;
   protected abstract _sendBatch(batch: QueuedMessages): Promise<QueuedMessages>;

--- a/src/message-stream.ts
+++ b/src/message-stream.ts
@@ -141,7 +141,7 @@ interface StreamTracked {
  * @param {MessageStreamOptions} [options] The message stream options.
  */
 export class MessageStream extends PassThrough {
-  private _keepAliveHandle?: NodeJS.Timer;
+  private _keepAliveHandle?: NodeJS.Timeout;
   private _options: MessageStreamOptions;
   private _retrier: ExponentialRetry<StreamTracked>;
 

--- a/src/publisher/message-queues.ts
+++ b/src/publisher/message-queues.ts
@@ -34,7 +34,7 @@ import {promisify} from 'util';
 export abstract class MessageQueue extends EventEmitter {
   batchOptions: BatchPublishOptions;
   publisher: Publisher;
-  pending?: NodeJS.Timer;
+  pending?: NodeJS.Timeout;
 
   constructor(publisher: Publisher) {
     super();

--- a/test/publisher/message-queues.ts
+++ b/test/publisher/message-queues.ts
@@ -290,7 +290,7 @@ describe('Message Queues', () => {
         const maxMilliseconds = 1234;
 
         queue.batchOptions = {maxMilliseconds};
-        queue.pending = 1234 as unknown as NodeJS.Timer;
+        queue.pending = 1234 as unknown as NodeJS.Timeout;
         queue.add(fakeMessage, spy);
 
         clock.tick(maxMilliseconds);
@@ -560,7 +560,7 @@ describe('Message Queues', () => {
         it('should noop after adding if a publish is already pending', () => {
           const stub = sandbox.stub(queue, 'beginNextPublish');
 
-          queue.pending = 1234 as unknown as NodeJS.Timer;
+          queue.pending = 1234 as unknown as NodeJS.Timeout;
           queue.add(fakeMessage, spy);
 
           assert.strictEqual(stub.callCount, 0);
@@ -657,7 +657,7 @@ describe('Message Queues', () => {
       });
 
       it('should cancel any pending publishes', () => {
-        const fakeHandle = 1234 as unknown as NodeJS.Timer;
+        const fakeHandle = 1234 as unknown as NodeJS.Timeout;
         const stub = sandbox.stub(global, 'clearTimeout');
 
         queue.pending = fakeHandle;


### PR DESCRIPTION
This fixes our current inability to build due to a change in Node typings in the timer interfaces.

This doesn't cause any breaking changes because:
- It's only used for compilation for us
- The interfaces in question are used entirely internally, and should be used by users
