### PR TITLE
samples: missed import conversion in TS

### DIFF
--- a/samples/typescript/createSubscription.ts
+++ b/samples/typescript/createSubscription.ts
@@ -33,7 +33,7 @@
 // const subscriptionNameOrId = 'YOUR_SUBSCRIPTION_NAME_OR_ID';
 
 // Imports the Google Cloud client library
-const {PubSub} = require('@google-cloud/pubsub');
+import {PubSub} from '@google-cloud/pubsub';
 
 // Creates a client; cache this for further use
 const pubSubClient = new PubSub();


### PR DESCRIPTION
I caught this while publishing all of the TypeScript samples.
