### PR TITLE
chore: fix build errors due to non-semver upstream version change

### DIFF
--- a/package.json
+++ b/package.json
@@ -51,7 +51,7 @@
     "@google-cloud/precise-date": "^4.0.0",
     "@google-cloud/projectify": "^4.0.0",
     "@google-cloud/promisify": "^4.0.0",
-    "@opentelemetry/api": "^1.6.0",
+    "@opentelemetry/api": "~1.8.0",
     "@opentelemetry/semantic-conventions": "~1.21.0",
     "arrify": "^2.0.0",
     "extend": "^3.0.2",


### PR DESCRIPTION
This fixes the (for now) breaking changes we got from 1.9.0 of `@opentelemetry/api`.
