### PR TITLE
build: shift typeless bot invocation into library package

### DIFF
--- a/owlbot.py
+++ b/owlbot.py
@@ -12,16 +12,22 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import synthtool.languages.node as node
+from synthtool.languages import node
+from synthtool import shell
+from synthtool.log import logger
 
 # Generate JS samples from TS.
-node.typeless_samples_hermetic()
+# node.typeless_samples_hermetic()
 
 # We need to run this before the main owlbot processing, to make
 # sure quickstart.js gets gts fixed before the README is generated.
 # This needs to be worked out more properly, this is temporary.
+logger.debug("Run typeless sample bot")
 node.install()
-node.fix()
+shell.run(["npm", "run", "typeless"])
+
+# node.fix()
+
 
 # Main OwlBot processing.
 node.owlbot_main(templates_excludes=[

--- a/package.json
+++ b/package.json
@@ -45,7 +45,8 @@
     "benchwrapper": "node bin/benchwrapper.js",
     "prelint": "cd samples; npm link ../; npm install",
     "precompile": "gts clean",
-    "typeless": "cd samples; npm run typeless"
+    "typeless": "npx typeless-sample-bot --outputpath samples --targets samples --recursive",
+    "posttypeless": "npm run fix"
   },
   "dependencies": {
     "@google-cloud/paginator": "^5.0.0",
@@ -64,6 +65,7 @@
     "p-defer": "^3.0.0"
   },
   "devDependencies": {
+    "@google-cloud/typeless-sample-bot": "^2.1.0",
     "@grpc/proto-loader": "^0.7.0",
     "@opentelemetry/core": "^1.17.0",
     "@opentelemetry/sdk-trace-base": "^1.17.0",

--- a/package.json
+++ b/package.json
@@ -44,7 +44,8 @@
     "predocs-test": "npm run docs",
     "benchwrapper": "node bin/benchwrapper.js",
     "prelint": "cd samples; npm link ../; npm install",
-    "precompile": "gts clean"
+    "precompile": "gts clean",
+    "typeless": "cd samples; npm run typeless"
   },
   "dependencies": {
     "@google-cloud/paginator": "^5.0.0",

--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
     "prelint": "cd samples; npm link ../; npm install",
     "precompile": "gts clean",
     "typeless": "npx typeless-sample-bot --outputpath samples --targets samples --recursive",
-    "posttypeless": "npm run fix"
+    "posttypeless": "cd samples; npm i; cd ..; npm run fix"
   },
   "dependencies": {
     "@google-cloud/paginator": "^5.0.0",

--- a/samples/package.json
+++ b/samples/package.json
@@ -18,9 +18,7 @@
     "sampletsc": "cd typescript && tsc -p . && cd ..",
     "compile": "npm run tsc && npm run sampletsc",
     "clean": "gts clean && rm -rf build/",
-    "precompile": "npm run clean",
-    "typeless": "npx typeless-sample-bot --outputpath . --targets . --recursive",
-    "posttypeless": "gts fix"
+    "precompile": "npm run clean"
   },
   "dependencies": {
     "@google-cloud/opentelemetry-cloud-trace-exporter": "^2.0.0",
@@ -37,7 +35,6 @@
   },
   "devDependencies": {
     "@google-cloud/bigquery": "^7.0.0",
-    "@google-cloud/typeless-sample-bot": "^2.1.0",
     "@types/chai": "^4.2.16",
     "chai": "^4.2.0",
     "gts": "^5.0.0",

--- a/samples/package.json
+++ b/samples/package.json
@@ -18,7 +18,9 @@
     "sampletsc": "cd typescript && tsc -p . && cd ..",
     "compile": "npm run tsc && npm run sampletsc",
     "clean": "gts clean && rm -rf build/",
-    "precompile": "npm run clean"
+    "precompile": "npm run clean",
+    "typeless": "typeless-sample-bot --outputpath . --targets . --recursive",
+    "posttypeless": "gts fix"
   },
   "dependencies": {
     "@google-cloud/opentelemetry-cloud-trace-exporter": "^2.0.0",
@@ -35,6 +37,7 @@
   },
   "devDependencies": {
     "@google-cloud/bigquery": "^7.0.0",
+    "@google-cloud/typeless-sample-bot": "^2.1.0",
     "@types/chai": "^4.2.16",
     "chai": "^4.2.0",
     "gts": "^5.0.0",

--- a/samples/package.json
+++ b/samples/package.json
@@ -19,7 +19,7 @@
     "compile": "npm run tsc && npm run sampletsc",
     "clean": "gts clean && rm -rf build/",
     "precompile": "npm run clean",
-    "typeless": "typeless-sample-bot --outputpath . --targets . --recursive",
+    "typeless": "npx typeless-sample-bot --outputpath . --targets . --recursive",
     "posttypeless": "gts fix"
   },
   "dependencies": {

--- a/test/pubsub.ts
+++ b/test/pubsub.ts
@@ -308,6 +308,7 @@ describe('PubSub', () => {
       const options: pubsubTypes.ClientConfig = {
         enableOpenTelemetryTracing: true,
       };
+      // eslint-disable-next-line @typescript-eslint/no-unused-vars
       const pubsub = new PubSub(options);
       assert.strictEqual(
         tracing.isEnabled(),


### PR DESCRIPTION
This contains one linter fix, and (more importantly) moves the typeless bot processing into the library project, and out of OwlBot. I wasn't sure where to put it before anyway, but I think this is a more sane approach (along with us moving `gts fix` out of hermetic).

The OwlBot.py changes are somewhat temporary - I want to go ahead and update OwlBot as well, but I haven't. I'll come back and clean up OwlBot.py after that.

