### PR TITLE
samples: various sample and doc improvements we had queued up

### DIFF
--- a/samples/listenForMessagesWithExactlyOnceDelivery.js
+++ b/samples/listenForMessagesWithExactlyOnceDelivery.js
@@ -1,4 +1,4 @@
-// Copyright 2022 Google LLC
+// Copyright 2022-2024 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -38,8 +38,11 @@
 // Imports the Google Cloud client library
 const {PubSub} = require('@google-cloud/pubsub');
 
-// Creates a client; cache this for further use
-const pubSubClient = new PubSub();
+// Pub/Sub's exactly once delivery guarantee only applies when subscribers connect to the service in the same region.
+// For list of locational endpoints for Pub/Sub, see https://cloud.google.com/pubsub/docs/reference/service_apis_overview#list_of_locational_endpoints
+const pubSubClient = new PubSub({
+  apiEndpoint: 'us-west1-pubsub.googleapis.com:443',
+});
 
 async function listenForMessagesWithExactlyOnceDelivery(
   subscriptionNameOrId,

--- a/samples/publishAvroRecords.js
+++ b/samples/publishAvroRecords.js
@@ -1,4 +1,4 @@
-// Copyright 2019-2021 Google LLC
+// Copyright 2019-2024 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -46,8 +46,10 @@ const fs = require('fs');
 const pubSubClient = new PubSub();
 
 async function publishAvroRecords(topicNameOrId) {
-  // Get the topic metadata to learn about its schema encoding.
+  // Cache topic objects (publishers) and reuse them.
   const topic = pubSubClient.topic(topicNameOrId);
+
+  // Get the topic metadata to learn about its schema encoding.
   const [topicMetadata] = await topic.getMetadata();
   const topicSchemaMetadata = topicMetadata.schemaSettings;
 

--- a/samples/publishBatchedMessages.js
+++ b/samples/publishBatchedMessages.js
@@ -1,4 +1,4 @@
-// Copyright 2019-2023 Google LLC
+// Copyright 2019-2024 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -53,6 +53,7 @@ async function publishBatchedMessages(
   // Publishes the message as a string, e.g. "Hello, world!" or JSON.stringify(someObject)
   const dataBuffer = Buffer.from(data);
 
+  // Cache topic objects (publishers) and reuse them.
   const publishOptions = {
     batching: {
       maxMessages: maxMessages,

--- a/samples/publishMessage.js
+++ b/samples/publishMessage.js
@@ -1,4 +1,4 @@
-// Copyright 2019-2023 Google LLC
+// Copyright 2019-2024 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -47,10 +47,11 @@ async function publishMessage(topicNameOrId, data) {
   // Publishes the message as a string, e.g. "Hello, world!" or JSON.stringify(someObject)
   const dataBuffer = Buffer.from(data);
 
+  // Cache topic objects (publishers) and reuse them.
+  const topic = pubSubClient.topic(topicNameOrId);
+
   try {
-    const messageId = await pubSubClient
-      .topic(topicNameOrId)
-      .publishMessage({data: dataBuffer});
+    const messageId = topic.publishMessage({data: dataBuffer});
     console.log(`Message ${messageId} published.`);
   } catch (error) {
     console.error(`Received error while publishing: ${error.message}`);

--- a/samples/publishMessageWithCustomAttributes.js
+++ b/samples/publishMessageWithCustomAttributes.js
@@ -1,4 +1,4 @@
-// Copyright 2019-2023 Google LLC
+// Copyright 2019-2024 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -52,9 +52,13 @@ async function publishMessageWithCustomAttributes(topicNameOrId, data) {
     username: 'gcp',
   };
 
-  const messageId = await pubSubClient
-    .topic(topicNameOrId)
-    .publishMessage({data: dataBuffer, attributes: customAttributes});
+  // Cache topic objects (publishers) and reuse them.
+  const topic = pubSubClient.topic(topicNameOrId);
+
+  const messageId = topic.publishMessage({
+    data: dataBuffer,
+    attributes: customAttributes,
+  });
   console.log(`Message ${messageId} published.`);
 }
 // [END pubsub_publish_custom_attributes]

--- a/samples/publishOrderedMessage.js
+++ b/samples/publishOrderedMessage.js
@@ -62,6 +62,10 @@ async function publishOrderedMessage(topicNameOrId, data, orderingKey) {
   };
 
   // Cache topic objects (publishers) and reuse them.
+  //
+  // Pub/Sub's ordered delivery guarantee only applies when publishes for an ordering
+  // key are in the same region. For list of locational endpoints for Pub/Sub, see:
+  // https://cloud.google.com/pubsub/docs/reference/service_apis_overview#list_of_locational_endpoints
   const publishOptions = {
     messageOrdering: true,
   };

--- a/samples/publishOrderedMessage.js
+++ b/samples/publishOrderedMessage.js
@@ -1,4 +1,4 @@
-// Copyright 2019-2023 Google LLC
+// Copyright 2019-2024 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -61,14 +61,14 @@ async function publishOrderedMessage(topicNameOrId, data, orderingKey) {
     orderingKey: orderingKey,
   };
 
+  // Cache topic objects (publishers) and reuse them.
   const publishOptions = {
     messageOrdering: true,
   };
+  const topic = pubSubClient.topic(topicNameOrId, publishOptions);
 
   // Publishes the message
-  const messageId = await pubSubClient
-    .topic(topicNameOrId, publishOptions)
-    .publishMessage(message);
+  const messageId = topic.publishMessage(message);
 
   console.log(`Message ${messageId} published.`);
 

--- a/samples/publishProtobufMessages.js
+++ b/samples/publishProtobufMessages.js
@@ -1,4 +1,4 @@
-// Copyright 2019-2021 Google LLC
+// Copyright 2019-2024 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -45,8 +45,10 @@ const protobuf = require('protobufjs');
 const pubSubClient = new PubSub();
 
 async function publishProtobufMessages(topicNameOrId) {
-  // Get the topic metadata to learn about its schema.
+  // Cache topic objects (publishers) and reuse them.
   const topic = pubSubClient.topic(topicNameOrId);
+
+  // Get the topic metadata to learn about its schema.
   const [topicMetadata] = await topic.getMetadata();
   const topicSchemaMetadata = topicMetadata.schemaSettings;
 
@@ -87,7 +89,7 @@ async function publishProtobufMessages(topicNameOrId) {
     return;
   }
 
-  const messageId = await topic.publish(dataBuffer);
+  const messageId = await topic.publishMessage({data: dataBuffer});
   console.log(`Protobuf message ${messageId} published.`);
 }
 // [END pubsub_publish_proto_messages]

--- a/samples/publishWithFlowControl.js
+++ b/samples/publishWithFlowControl.js
@@ -1,4 +1,4 @@
-// Copyright 2021 Google LLC
+// Copyright 2021-2024 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -50,7 +50,7 @@ async function publishWithFlowControl(topicNameOrId) {
     },
   };
 
-  // Get a publisher.
+  // Get a publisher. Cache topic objects (publishers) and reuse them.
   const topic = pubSubClient.topic(topicNameOrId, options);
 
   // For flow controlled publishing, we'll use a publisher flow controller

--- a/samples/publishWithOpenTelemetryTracing.js
+++ b/samples/publishWithOpenTelemetryTracing.js
@@ -86,7 +86,10 @@ async function publishMessage(topicNameOrId, data) {
   // Publishes the message as a string, e.g. "Hello, world!"
   // or JSON.stringify(someObject)
   const dataBuffer = Buffer.from(data);
+
+  // Cache topic objects (publishers) and reuse them.
   const publisher = pubSubClient.topic(topicNameOrId);
+
   const messageId = await publisher.publishMessage({data: dataBuffer});
   console.log(`Message ${messageId} published.`);
 

--- a/samples/publishWithRetrySettings.js
+++ b/samples/publishWithRetrySettings.js
@@ -1,4 +1,4 @@
-// Copyright 2019-2023 Google LLC
+// Copyright 2019-2024 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -47,6 +47,12 @@ async function publishWithRetrySettings(topicNameOrId, data) {
   // Retry settings control how the publisher handles retryable failures. Default values are shown.
   // The `retryCodes` array determines which grpc errors will trigger an automatic retry.
   // The `backoffSettings` object lets you specify the behaviour of retries over time.
+  //
+  // Reference this document to see the current defaults for publishing:
+  // https://github.com/googleapis/nodejs-pubsub/blob/6e2c28a9298a49dc1b194ce747ff5258c8df6deb/src/v1/publisher_client_config.json#L59
+  //
+  // Please note that _all_ items must be included when passing these settings to topic().
+  // Otherwise, unpredictable (incorrect) defaults may be assumed.
   const retrySettings = {
     retryCodes: [
       10, // 'ABORTED'
@@ -63,17 +69,17 @@ async function publishWithRetrySettings(topicNameOrId, data) {
       initialRetryDelayMillis: 100,
       // The multiplier by which to increase the delay time between the completion
       // of failed requests, and the initiation of the subsequent retrying request.
-      retryDelayMultiplier: 1.3,
+      retryDelayMultiplier: 4,
       // The maximum delay time, in milliseconds, between requests.
       // When this value is reached, retryDelayMultiplier will no longer be used to increase delay time.
       maxRetryDelayMillis: 60000,
       // The initial timeout parameter to the request.
-      initialRpcTimeoutMillis: 5000,
+      initialRpcTimeoutMillis: 60000,
       // The multiplier by which to increase the timeout parameter between failed requests.
       rpcTimeoutMultiplier: 1.0,
       // The maximum timeout parameter, in milliseconds, for a request. When this value is reached,
       // rpcTimeoutMultiplier will no longer be used to increase the timeout.
-      maxRpcTimeoutMillis: 600000,
+      maxRpcTimeoutMillis: 60000,
       // The total time, in milliseconds, starting from when the initial request is sent,
       // after which an error will be returned, regardless of the retrying attempts made meanwhile.
       totalTimeoutMillis: 600000,

--- a/samples/resumePublish.js
+++ b/samples/resumePublish.js
@@ -1,4 +1,4 @@
-// Copyright 2019-2023 Google LLC
+// Copyright 2019-2024 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -52,8 +52,14 @@ async function resumePublish(topicNameOrId, data, orderingKey) {
     messageOrdering: true,
   };
 
-  // Publishes the message
+  // Cache topic objects (publishers) and reuse them.
+  //
+  // Pub/Sub's ordered delivery guarantee only applies when publishes for an ordering
+  // key are in the same region. For list of locational endpoints for Pub/Sub, see:
+  // https://cloud.google.com/pubsub/docs/reference/service_apis_overview#list_of_locational_endpoints
   const publisher = pubSubClient.topic(topicNameOrId, publishOptions);
+
+  // Publishes the message
   try {
     const message = {
       data: dataBuffer,

--- a/samples/typescript/listenForMessagesWithExactlyOnceDelivery.ts
+++ b/samples/typescript/listenForMessagesWithExactlyOnceDelivery.ts
@@ -1,4 +1,4 @@
-// Copyright 2022 Google LLC
+// Copyright 2022-2024 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -34,8 +34,11 @@
 // Imports the Google Cloud client library
 import {Message, PubSub, AckError} from '@google-cloud/pubsub';
 
-// Creates a client; cache this for further use
-const pubSubClient = new PubSub();
+// Pub/Sub's exactly once delivery guarantee only applies when subscribers connect to the service in the same region.
+// For list of locational endpoints for Pub/Sub, see https://cloud.google.com/pubsub/docs/reference/service_apis_overview#list_of_locational_endpoints
+const pubSubClient = new PubSub({
+  apiEndpoint: 'us-west1-pubsub.googleapis.com:443',
+});
 
 async function listenForMessagesWithExactlyOnceDelivery(
   subscriptionNameOrId: string,

--- a/samples/typescript/publishAvroRecords.ts
+++ b/samples/typescript/publishAvroRecords.ts
@@ -1,4 +1,4 @@
-// Copyright 2019-2021 Google LLC
+// Copyright 2019-2024 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -47,8 +47,10 @@ interface ProvinceObject {
 }
 
 async function publishAvroRecords(topicNameOrId: string) {
-  // Get the topic metadata to learn about its schema encoding.
+  // Cache topic objects (publishers) and reuse them.
   const topic = pubSubClient.topic(topicNameOrId);
+
+  // Get the topic metadata to learn about its schema encoding.
   const [topicMetadata] = await topic.getMetadata();
   const topicSchemaMetadata = topicMetadata.schemaSettings;
 

--- a/samples/typescript/publishBatchedMessages.ts
+++ b/samples/typescript/publishBatchedMessages.ts
@@ -1,4 +1,4 @@
-// Copyright 2019-2023 Google LLC
+// Copyright 2019-2024 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -49,6 +49,7 @@ async function publishBatchedMessages(
   // Publishes the message as a string, e.g. "Hello, world!" or JSON.stringify(someObject)
   const dataBuffer = Buffer.from(data);
 
+  // Cache topic objects (publishers) and reuse them.
   const publishOptions: PublishOptions = {
     batching: {
       maxMessages: maxMessages,

--- a/samples/typescript/publishMessage.ts
+++ b/samples/typescript/publishMessage.ts
@@ -1,4 +1,4 @@
-// Copyright 2019-2023 Google LLC
+// Copyright 2019-2024 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -43,10 +43,11 @@ async function publishMessage(topicNameOrId: string, data: string) {
   // Publishes the message as a string, e.g. "Hello, world!" or JSON.stringify(someObject)
   const dataBuffer = Buffer.from(data);
 
+  // Cache topic objects (publishers) and reuse them.
+  const topic = pubSubClient.topic(topicNameOrId);
+
   try {
-    const messageId = await pubSubClient
-      .topic(topicNameOrId)
-      .publishMessage({data: dataBuffer});
+    const messageId = topic.publishMessage({data: dataBuffer});
     console.log(`Message ${messageId} published.`);
   } catch (error) {
     console.error(

--- a/samples/typescript/publishMessageWithCustomAttributes.ts
+++ b/samples/typescript/publishMessageWithCustomAttributes.ts
@@ -1,4 +1,4 @@
-// Copyright 2019-2023 Google LLC
+// Copyright 2019-2024 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -55,9 +55,13 @@ async function publishMessageWithCustomAttributes(
     username: 'gcp',
   };
 
-  const messageId = await pubSubClient
-    .topic(topicNameOrId)
-    .publishMessage({data: dataBuffer, attributes: customAttributes});
+  // Cache topic objects (publishers) and reuse them.
+  const topic = pubSubClient.topic(topicNameOrId);
+
+  const messageId = topic.publishMessage({
+    data: dataBuffer,
+    attributes: customAttributes,
+  });
   console.log(`Message ${messageId} published.`);
 }
 // [END pubsub_publish_custom_attributes]

--- a/samples/typescript/publishOrderedMessage.ts
+++ b/samples/typescript/publishOrderedMessage.ts
@@ -62,6 +62,10 @@ async function publishOrderedMessage(
   };
 
   // Cache topic objects (publishers) and reuse them.
+  //
+  // Pub/Sub's ordered delivery guarantee only applies when publishes for an ordering
+  // key are in the same region. For list of locational endpoints for Pub/Sub, see:
+  // https://cloud.google.com/pubsub/docs/reference/service_apis_overview#list_of_locational_endpoints
   const publishOptions: PublishOptions = {
     messageOrdering: true,
   };

--- a/samples/typescript/publishOrderedMessage.ts
+++ b/samples/typescript/publishOrderedMessage.ts
@@ -1,4 +1,4 @@
-// Copyright 2019-2023 Google LLC
+// Copyright 2019-2024 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -61,14 +61,14 @@ async function publishOrderedMessage(
     orderingKey: orderingKey,
   };
 
+  // Cache topic objects (publishers) and reuse them.
   const publishOptions: PublishOptions = {
     messageOrdering: true,
   };
+  const topic = pubSubClient.topic(topicNameOrId, publishOptions);
 
   // Publishes the message
-  const messageId = await pubSubClient
-    .topic(topicNameOrId, publishOptions)
-    .publishMessage(message);
+  const messageId = topic.publishMessage(message);
 
   console.log(`Message ${messageId} published.`);
 

--- a/samples/typescript/publishProtobufMessages.ts
+++ b/samples/typescript/publishProtobufMessages.ts
@@ -1,4 +1,4 @@
-// Copyright 2019-2021 Google LLC
+// Copyright 2019-2024 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -46,8 +46,10 @@ interface ProvinceObject {
 }
 
 async function publishProtobufMessages(topicNameOrId: string) {
-  // Get the topic metadata to learn about its schema.
+  // Cache topic objects (publishers) and reuse them.
   const topic = pubSubClient.topic(topicNameOrId);
+
+  // Get the topic metadata to learn about its schema.
   const [topicMetadata] = await topic.getMetadata();
   const topicSchemaMetadata = topicMetadata.schemaSettings;
 
@@ -88,7 +90,7 @@ async function publishProtobufMessages(topicNameOrId: string) {
     return;
   }
 
-  const messageId = await topic.publish(dataBuffer);
+  const messageId = await topic.publishMessage({data: dataBuffer});
   console.log(`Protobuf message ${messageId} published.`);
 }
 // [END pubsub_publish_proto_messages]

--- a/samples/typescript/publishWithFlowControl.ts
+++ b/samples/typescript/publishWithFlowControl.ts
@@ -1,4 +1,4 @@
-// Copyright 2021 Google LLC
+// Copyright 2021-2024 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -46,7 +46,7 @@ async function publishWithFlowControl(topicNameOrId: string) {
     },
   };
 
-  // Get a publisher.
+  // Get a publisher. Cache topic objects (publishers) and reuse them.
   const topic = pubSubClient.topic(topicNameOrId, options);
 
   // For flow controlled publishing, we'll use a publisher flow controller

--- a/samples/typescript/publishWithOpenTelemetryTracing.ts
+++ b/samples/typescript/publishWithOpenTelemetryTracing.ts
@@ -78,7 +78,10 @@ async function publishMessage(topicNameOrId: string, data: string) {
   // Publishes the message as a string, e.g. "Hello, world!"
   // or JSON.stringify(someObject)
   const dataBuffer = Buffer.from(data);
+
+  // Cache topic objects (publishers) and reuse them.
   const publisher = pubSubClient.topic(topicNameOrId);
+
   const messageId = await publisher.publishMessage({data: dataBuffer});
   console.log(`Message ${messageId} published.`);
 

--- a/samples/typescript/publishWithRetrySettings.ts
+++ b/samples/typescript/publishWithRetrySettings.ts
@@ -35,35 +35,10 @@
 
 // Imports the Google Cloud client library. v1 is for the lower level
 // proto access.
-import {v1} from '@google-cloud/pubsub';
+import {PubSub} from '@google-cloud/pubsub';
 
-// Creates a publisher client.
-const publisherClient = new v1.PublisherClient({
-  // optional auth parameters
-});
-
-async function publishWithRetrySettings(
-  projectId: string,
-  topicNameOrId: string,
-  data: string
-) {
-  const formattedTopic = publisherClient.projectTopicPath(
-    projectId,
-    topicNameOrId
-  );
-
-  // Publishes the message as a string, e.g. "Hello, world!" or JSON.stringify(someObject)
-  const dataBuffer = Buffer.from(data);
-  const messagesElement = {
-    data: dataBuffer,
-  };
-  const messages = [messagesElement];
-
-  // Build the request
-  const request = {
-    topic: formattedTopic,
-    messages: messages,
-  };
+async function publishWithRetrySettings(topicNameOrId: string, data: string) {
+  const pubsubClient = new PubSub();
 
   // Retry settings control how the publisher handles retryable failures. Default values are shown.
   // The `retryCodes` array determines which grpc errors will trigger an automatic retry.
@@ -101,19 +76,25 @@ async function publishWithRetrySettings(
     },
   };
 
-  const [response] = await publisherClient.publish(request, {
-    retry: retrySettings,
+  // Cache topic objects (publishers) and reuse them.
+  const topic = pubsubClient.topic(topicNameOrId, {
+    gaxOpts: {
+      retry: retrySettings,
+    },
   });
-  console.log(`Message ${response.messageIds} published.`);
+
+  // Publishes the message as a string, e.g. "Hello, world!" or JSON.stringify(someObject)
+  const dataBuffer = Buffer.from(data);
+  const messageId = await topic.publishMessage({data: dataBuffer});
+  console.log(`Message ${messageId} published.`);
 }
 // [END pubsub_publisher_retry_settings]
 
 function main(
-  projectId = 'YOUR_PROJECT_ID',
   topicNameOrId = 'YOUR_TOPIC_NAME_OR_ID',
   data = JSON.stringify({foo: 'bar'})
 ) {
-  publishWithRetrySettings(projectId, topicNameOrId, data).catch(err => {
+  publishWithRetrySettings(topicNameOrId, data).catch(err => {
     console.error(err.message);
     process.exitCode = 1;
   });

--- a/samples/typescript/publishWithRetrySettings.ts
+++ b/samples/typescript/publishWithRetrySettings.ts
@@ -1,4 +1,4 @@
-// Copyright 2019-2023 Google LLC
+// Copyright 2019-2024 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -43,6 +43,12 @@ async function publishWithRetrySettings(topicNameOrId: string, data: string) {
   // Retry settings control how the publisher handles retryable failures. Default values are shown.
   // The `retryCodes` array determines which grpc errors will trigger an automatic retry.
   // The `backoffSettings` object lets you specify the behaviour of retries over time.
+  //
+  // Reference this document to see the current defaults for publishing:
+  // https://github.com/googleapis/nodejs-pubsub/blob/6e2c28a9298a49dc1b194ce747ff5258c8df6deb/src/v1/publisher_client_config.json#L59
+  //
+  // Please note that _all_ items must be included when passing these settings to topic().
+  // Otherwise, unpredictable (incorrect) defaults may be assumed.
   const retrySettings = {
     retryCodes: [
       10, // 'ABORTED'
@@ -59,17 +65,17 @@ async function publishWithRetrySettings(topicNameOrId: string, data: string) {
       initialRetryDelayMillis: 100,
       // The multiplier by which to increase the delay time between the completion
       // of failed requests, and the initiation of the subsequent retrying request.
-      retryDelayMultiplier: 1.3,
+      retryDelayMultiplier: 4,
       // The maximum delay time, in milliseconds, between requests.
       // When this value is reached, retryDelayMultiplier will no longer be used to increase delay time.
       maxRetryDelayMillis: 60000,
       // The initial timeout parameter to the request.
-      initialRpcTimeoutMillis: 5000,
+      initialRpcTimeoutMillis: 60000,
       // The multiplier by which to increase the timeout parameter between failed requests.
       rpcTimeoutMultiplier: 1.0,
       // The maximum timeout parameter, in milliseconds, for a request. When this value is reached,
       // rpcTimeoutMultiplier will no longer be used to increase the timeout.
-      maxRpcTimeoutMillis: 600000,
+      maxRpcTimeoutMillis: 60000,
       // The total time, in milliseconds, starting from when the initial request is sent,
       // after which an error will be returned, regardless of the retrying attempts made meanwhile.
       totalTimeoutMillis: 600000,

--- a/samples/typescript/resumePublish.ts
+++ b/samples/typescript/resumePublish.ts
@@ -1,4 +1,4 @@
-// Copyright 2019-2023 Google LLC
+// Copyright 2019-2024 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -52,8 +52,14 @@ async function resumePublish(
     messageOrdering: true,
   };
 
-  // Publishes the message
+  // Cache topic objects (publishers) and reuse them.
+  //
+  // Pub/Sub's ordered delivery guarantee only applies when publishes for an ordering
+  // key are in the same region. For list of locational endpoints for Pub/Sub, see:
+  // https://cloud.google.com/pubsub/docs/reference/service_apis_overview#list_of_locational_endpoints
   const publisher = pubSubClient.topic(topicNameOrId, publishOptions);
+
+  // Publishes the message
   try {
     const message = {
       data: dataBuffer,

--- a/src/message-queues.ts
+++ b/src/message-queues.ts
@@ -55,6 +55,9 @@ export interface QueuedMessage {
  */
 export type QueuedMessages = Array<QueuedMessage>;
 
+/**
+ * Batching options for sending acks and modacks back to the server.
+ */
 export interface BatchOptions {
   callOptions?: CallOptions;
   maxMessages?: number;

--- a/src/subscriber.ts
+++ b/src/subscriber.ts
@@ -560,7 +560,8 @@ export class Message implements tracing.MessageWithAttributes {
  *     ever have, while it's under library control.
  * @property {Duration} [maxAckDeadline] The maximum time that ackDeadline should
  *     ever have, while it's under library control.
- * @property {BatchOptions} [batching] Request batching options.
+ * @property {BatchOptions} [batching] Request batching options; this is for
+ *     batching acks and modacks being sent back to the server.
  * @property {FlowControlOptions} [flowControl] Flow control options.
  * @property {boolean} [useLegacyFlowControl] Disables enforcing flow control
  *     settings at the Cloud PubSub server and uses the less accurate method


### PR DESCRIPTION
    samples: update EOD sample with endpoint
    docs: clarify what subscriber batching means
    samples: update publishWithRetrySettings with new defaults; add comment about including all items
    samples: convert publishWithRetrySettings to use veneer
    samples: update publishing samples to clarify that topic objects should be cached; also fix a usage of publish()
