### PR TITLE
build: revert gts version for system test fixtures, update TS version to match main package

### DIFF
--- a/system-test/fixtures/sample/package.json
+++ b/system-test/fixtures/sample/package.json
@@ -17,7 +17,7 @@
   },
   "devDependencies": {
     "@types/node": "^20.0.0",
-    "typescript": "^4.6.4",
-    "gts": "^6.0.0"
+    "typescript": "^5.1.6",
+    "gts": "^5.0.0"
   }
 }


### PR DESCRIPTION
Reverts https://github.com/googleapis/nodejs-pubsub/pull/1986

...but also updates the system test fixture to have the same versions as nodejs-pubsub.
