### PR TITLE
maxOutstandingMessages per stream

### DIFF
--- a/src/message-stream.ts
+++ b/src/message-stream.ts
@@ -321,7 +321,7 @@ export class MessageStream extends PassThrough {
         : this._subscriber.maxMessages / this._streams.length,
       maxOutstandingBytes: this._subscriber.useLegacyFlowControl
         ? 0
-        : this._subscriber.maxBytes,
+        : this._subscriber.maxBytes / this._streams.length,
     };
     const otherArgs = {
       headers: {

--- a/src/message-stream.ts
+++ b/src/message-stream.ts
@@ -318,7 +318,7 @@ export class MessageStream extends PassThrough {
       streamAckDeadlineSeconds: this._subscriber.ackDeadline,
       maxOutstandingMessages: this._subscriber.useLegacyFlowControl
         ? 0
-        : this._subscriber.maxMessages,
+        : this._subscriber.maxMessages / this._streams.length,
       maxOutstandingBytes: this._subscriber.useLegacyFlowControl
         ? 0
         : this._subscriber.maxBytes,
@@ -328,7 +328,6 @@ export class MessageStream extends PassThrough {
         'x-goog-request-params': 'subscription=' + this._subscriber.name,
       },
     };
-
     const stream: PullStream = client.streamingPull({deadline, otherArgs});
     this._replaceStream(index, stream);
     stream.write(request);


### PR DESCRIPTION
the `maxOutstandingMessages` is set per stream so we should divide by num of streams, right?