### PR TITLE
feat: use specific W3CTraceContextPropagator for OTel

### DIFF
--- a/package.json
+++ b/package.json
@@ -53,6 +53,7 @@
     "@google-cloud/projectify": "^5.0.0",
     "@google-cloud/promisify": "^5.0.0",
     "@opentelemetry/api": "~1.9.0",
+    "@opentelemetry/core": "^1.30.1",
     "@opentelemetry/semantic-conventions": "~1.32.0",
     "arrify": "^2.0.0",
     "extend": "^3.0.2",
@@ -65,7 +66,6 @@
   },
   "devDependencies": {
     "@grpc/proto-loader": "^0.7.13",
-    "@opentelemetry/core": "^1.17.0",
     "@opentelemetry/sdk-trace-base": "^1.17.0",
     "@types/duplexify": "^3.6.4",
     "@types/extend": "^3.0.4",

--- a/src/telemetry-tracing.ts
+++ b/src/telemetry-tracing.ts
@@ -19,7 +19,6 @@ import {
   Span,
   context,
   trace,
-  propagation,
   SpanKind,
   TextMapGetter,
   TextMapSetter,
@@ -811,7 +810,11 @@ export function extractSpan(
   let context: Context | undefined;
 
   if (keys.includes(modernAttributeName)) {
-    context = w3cTraceContextPropagator.extract(ROOT_CONTEXT, message, pubsubGetter);
+    context = w3cTraceContextPropagator.extract(
+      ROOT_CONTEXT,
+      message,
+      pubsubGetter,
+    );
   }
 
   const span = PubsubSpans.createReceiveSpan(

--- a/src/telemetry-tracing.ts
+++ b/src/telemetry-tracing.ts
@@ -27,6 +27,7 @@ import {
   Context,
   Link,
 } from '@opentelemetry/api';
+import {W3CTraceContextPropagator} from '@opentelemetry/core';
 import {Attributes, PubsubMessage} from './publisher/pubsub-message';
 import {Duration} from './temporal';
 
@@ -69,6 +70,14 @@ export enum OpenTelemetryLevel {
    */
   Modern = 2,
 }
+
+/**
+ * The W3C trace context propagator, used for injecting/extracting trace context.
+ *
+ * @private
+ * @internal
+ */
+const w3cTraceContextPropagator = new W3CTraceContextPropagator();
 
 // True if user code elsewhere wants to enable OpenTelemetry support.
 let globallyEnabled = false;
@@ -749,7 +758,7 @@ export function injectSpan(span: Span, message: MessageWithAttributes): void {
 
   // Always do propagation injection with the trace context.
   const context = trace.setSpanContext(ROOT_CONTEXT, span.spanContext());
-  propagation.inject(context, message, pubsubSetter);
+  w3cTraceContextPropagator.inject(context, message, pubsubSetter);
 
   // Also put the direct reference to the Span object for while we're
   // passing it around in the client library.
@@ -802,7 +811,7 @@ export function extractSpan(
   let context: Context | undefined;
 
   if (keys.includes(modernAttributeName)) {
-    context = propagation.extract(ROOT_CONTEXT, message, pubsubGetter);
+    context = w3cTraceContextPropagator.extract(ROOT_CONTEXT, message, pubsubGetter);
   }
 
   const span = PubsubSpans.createReceiveSpan(


### PR DESCRIPTION
Replaces the use of the global OpenTelemetry propagator (`propagation`) with a specific instance of `W3CTraceContextPropagator` within the `telemetry-tracing.ts` module.

This ensures that trace context propagation for Pub/Sub messages always uses the W3C format via the `googclient_traceparent` attribute, regardless of the global propagator configured by user code. This maintains consistent tracing behaviour as it moves between library instances as a Pub/Sub attribute.

Fixes [#2005](https://github.com/googleapis/nodejs-pubsub/issues/2005) 🦕
