### PR TITLE
fix: Remove retried item from the queue during reset

### DIFF
--- a/src/exponential-retry.ts
+++ b/src/exponential-retry.ts
@@ -147,6 +147,7 @@ export class ExponentialRetry<T> {
   reset(item: T) {
     const retried = item as RetriedItem<T>;
     delete retried.retryInfo;
+    this._items.remove(retried);
   }
 
   // Takes a time delta and adds fuzz.

--- a/src/exponential-retry.ts
+++ b/src/exponential-retry.ts
@@ -146,8 +146,8 @@ export class ExponentialRetry<T> {
    */
   reset(item: T) {
     const retried = item as RetriedItem<T>;
-    delete retried.retryInfo;
     this._items.remove(retried);
+    delete retried.retryInfo;
   }
 
   // Takes a time delta and adds fuzz.

--- a/src/exponential-retry.ts
+++ b/src/exponential-retry.ts
@@ -146,6 +146,9 @@ export class ExponentialRetry<T> {
    */
   reset(item: T) {
     const retried = item as RetriedItem<T>;
+    if (!retried.retryInfo) {
+      return;
+    }
     this._items.remove(retried);
     delete retried.retryInfo;
   }


### PR DESCRIPTION
we are seeing accessional uncaught errors like such:
```
TypeError: Cannot read properties of undefined (reading 'nextRetry')
    at Heap.comparator [as compare] (/usr/src/app/node_modules/@tw/pubsub/build/src/exponential-retry.js:21:24)
    at Heap._sortNodeDown (/usr/src/app/node_modules/heap-js/dist/heap-js.umd.js:2148:43)
    at Heap.replace (/usr/src/app/node_modules/heap-js/dist/heap-js.umd.js:1987:18)
    at Heap.pop (/usr/src/app/node_modules/heap-js/dist/heap-js.umd.js:1902:29)
    at ExponentialRetry.doRetries (/usr/src/app/node_modules/@tw/pubsub/build/src/exponential-retry.js:117:29)
    at Timeout._onTimeout (/usr/src/app/node_modules/@tw/pubsub/build/src/exponential-retry.js:142:22)
    at listOnTimeout (node:internal/timers:573:17)
    at process.processTimers (node:internal/timers:514:7)
```
