### PR TITLE
chore: group renovate PRs for this repo, remove renovate template gen for now

### DIFF
--- a/owlbot.py
+++ b/owlbot.py
@@ -20,5 +20,6 @@ node.owlbot_main(templates_excludes=[
     '.github/PULL_REQUEST_TEMPLATE.md',
     '.github/release-please.yml',
     '.github/header-checker-lint.yaml',
-    '.eslintignore'
+    '.eslintignore',
+    'renovate.json'
 ])

--- a/renovate.json
+++ b/renovate.json
@@ -1,6 +1,7 @@
 {
   "extends": [
     "config:base",
+    "group:all",
     "docker:disable",
     ":disableDependencyDashboard"
   ],


### PR DESCRIPTION
We get a LOT of renovate PRs here. Long term, a better idea is to implement partials for these configs (thanks @leahecole :).
