### PR TITLE
fix: move off the remaining rc versions

### DIFF
--- a/package.json
+++ b/package.json
@@ -57,7 +57,7 @@
     "@opentelemetry/semantic-conventions": "~1.34.0",
     "arrify": "^2.0.0",
     "extend": "^3.0.2",
-    "google-auth-library": "^10.0.0-rc.1",
+    "google-auth-library": "^10.5.0",
     "google-gax": "^5.0.1-rc.0",
     "heap-js": "^2.6.0",
     "is-stream-ended": "^0.1.4",

--- a/package.json
+++ b/package.json
@@ -58,7 +58,7 @@
     "arrify": "^2.0.0",
     "extend": "^3.0.2",
     "google-auth-library": "^10.5.0",
-    "google-gax": "^5.0.1-rc.0",
+    "google-gax": "^5.0.5",
     "heap-js": "^2.6.0",
     "is-stream-ended": "^0.1.4",
     "lodash.snakecase": "^4.1.1",

--- a/samples/package.json
+++ b/samples/package.json
@@ -33,6 +33,7 @@
     "@opentelemetry/sdk-trace-node": "^1.17.0",
     "@opentelemetry/semantic-conventions": "^1.17.0",
     "avro-js": "^1.11.3",
+    "google-auth-library": "^10.5.0",
     "p-defer": "^3.0.0",
     "protobufjs": "~7.5.0"
   },


### PR DESCRIPTION
Some of the library dependencies were still pointing at rc versions. This mitigates that.
