### PR TITLE
fix(WaitForProcessing): Shutdown option `WaitForProcessing` never entered on subscription close

### DIFF
--- a/src/lease-manager.ts
+++ b/src/lease-manager.ts
@@ -106,6 +106,8 @@ export class LeaseManager extends EventEmitter {
    * Adds a message to the inventory, kicking off the deadline extender if it
    * isn't already running.
    *
+   * @fires LeaseManager#full
+   *
    * @param {Message} message The message.
    * @private
    */
@@ -141,6 +143,10 @@ export class LeaseManager extends EventEmitter {
   }
   /**
    * Removes ALL messages from inventory, and returns the ones removed.
+   *
+   * @fires LeaseManager#free
+   * @fires LeaseManager#empty
+   *
    * @private
    */
   clear(): Message[] {
@@ -197,6 +203,7 @@ export class LeaseManager extends EventEmitter {
    * messages are left over.
    *
    * @fires LeaseManager#free
+   * @fires LeaseManager#empty
    *
    * @param {Message} message The message to remove.
    * @private

--- a/src/subscriber.ts
+++ b/src/subscriber.ts
@@ -1000,7 +1000,7 @@ export class Subscriber extends EventEmitter {
     const shutdownStart = Date.now();
     if (
       behavior === SubscriberCloseBehaviors.WaitForProcessing &&
-      !this._inventory.isEmpty
+      !this._inventory.isEmpty()
     ) {
       const waitTimeout = timeout.subtract(FINAL_NACK_TIMEOUT);
 

--- a/src/subscriber.ts
+++ b/src/subscriber.ts
@@ -655,7 +655,7 @@ export class Message implements tracing.MessageWithAttributes {
  *     close() function.
  * @property {SubscriberCloseBehavior} [options.behavior] The behavior of the close operation.
  *     - NackImmediately: Sends nacks for all messages held by the client library, and
- *       wait for them to send.
+ *       wait for them to send. (default to match old behavior)
  *     - WaitForProcessing: Continues normal ack/nack and leasing processes until close
  *       to the timeout, then switches to NackImmediately behavior to close down.
  *     Use {@link SubscriberCloseBehaviors} for enum values.
@@ -970,9 +970,10 @@ export class Subscriber extends EventEmitter {
 
     const options = this._options.closeOptions;
 
-    // If no behavior is specified, default to Wait.
+    // If no behavior is specified, default to Nack. This most closely matches
+    // the old behavior.
     const behavior =
-      options?.behavior ?? SubscriberCloseBehaviors.WaitForProcessing;
+      options?.behavior ?? SubscriberCloseBehaviors.NackImmediately;
 
     // The timeout can't realistically be longer than the longest time we're willing
     // to lease messages.

--- a/system-test/pubsub.ts
+++ b/system-test/pubsub.ts
@@ -429,8 +429,8 @@ describe('pubsub', () => {
     const SUB_NAMES = [generateSubName(), generateSubName()];
     const SUB_DETACH_NAME = generateSubForDetach();
 
-    const thirty = Duration.from({minutes: 30});
-    const sixty = Duration.from({minutes: 60});
+    const thirty = Duration.from({seconds: 30});
+    const sixty = Duration.from({seconds: 60});
     const SUBSCRIPTIONS = [
       topic.subscription(SUB_NAMES[0], {minAckDeadline: thirty, maxAckDeadline: thirty}),
       topic.subscription(SUB_NAMES[1], {minAckDeadline: sixty, maxAckDeadline: sixty}),
@@ -660,8 +660,9 @@ describe('pubsub', () => {
       subscription.on('error', done);
 
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      subscription.on('message', (message: {data: any}) => {
+      subscription.on('message', message => {
         assert.deepStrictEqual(message.data, Buffer.from('hello'));
+        message.ack();
 
         if (++messageCount === 10) {
           subscription.close(done);

--- a/system-test/pubsub.ts
+++ b/system-test/pubsub.ts
@@ -659,7 +659,6 @@ describe('pubsub', () => {
 
       subscription.on('error', done);
 
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
       subscription.on('message', message => {
         assert.deepStrictEqual(message.data, Buffer.from('hello'));
         message.ack();

--- a/test/subscriber.ts
+++ b/test/subscriber.ts
@@ -106,7 +106,7 @@ class FakeLeaseManager extends EventEmitter {
   remove(message: s.Message): void {}
 
   _isEmpty = true;
-  get isEmpty() {
+  isEmpty(): boolean {
     return this._isEmpty;
   }
 }


### PR DESCRIPTION
As outlined in https://github.com/googleapis/nodejs-pubsub/issues/2117, the condition to enter the `WaitForProcessing` closing behavior of a subscription was checking against an `undefined` field `.isEmpty` of the inventory instead of checking for the `isEmpty()` method of the inventory.

In unit tests this went unnoticed since the field was set accordingly in the class under test.

This implicitly changes the default behavior of the subscription close functionality since the previous PR that introduced this functionality (https://github.com/googleapis/nodejs-pubsub/pull/2068) changed the default behavior without effect as the condition was never entered during `close()`.

___

Thank you for opening a Pull Request! Before submitting your PR, there are a few things you can do to make sure it goes smoothly:
- [x] Make sure to open an issue as a [bug/issue](https://github.com/googleapis/nodejs-pubsub/issues/new/choose) before writing your code!  That way we can discuss the change, evaluate designs, and agree on the general idea
- [x] Ensure the tests and linter pass
- [x] Code coverage does not decrease (if any source code was changed)
- [x] Appropriate docs were updated (if necessary)

Fixes #2117 🦕
