### PR TITLE
fix: rpcSpan closure logic in message-queues

### DIFF
--- a/src/publisher/message-queues.ts
+++ b/src/publisher/message-queues.ts
@@ -172,10 +172,11 @@ export abstract class MessageQueue extends EventEmitter {
 
       throw e;
     } finally {
-      messages.forEach(m => {
-        // We're finished with both the RPC and the whole publish operation,
-        // so close out all of the related spans.
-        rpcSpan?.end();
+      // We're finished with both the RPC and the whole publish operation,
+      // so close out all of the related spans.
+      // rpcSpan must be closed only once
+      rpcSpan?.end();
+      messages.forEach(m => {  
         tracing.PubsubEvents.publishEnd(m);
         m.parentSpan?.end();
       });


### PR DESCRIPTION
Ensure rpcSpan is closed only once after publish operation.

Thank you for opening a Pull Request! Before submitting your PR, there are a few things you can do to make sure it goes smoothly:
- [ ] Make sure to open an issue as a [bug/issue](https://github.com/googleapis/nodejs-pubsub/issues/new/choose) before writing your code!  That way we can discuss the change, evaluate designs, and agree on the general idea
- [ ] Ensure the tests and linter pass
- [ ] Code coverage does not decrease (if any source code was changed)
- [ ] Appropriate docs were updated (if necessary)

Fixes #[<2119> ](https://github.com/googleapis/nodejs-pubsub/issues/2119)🦕

Note: If you are opening a pull request against a `legacy` branch, PLEASE BE AWARE that we generally won't accept these except for things like important security fixes, and only for a limited time.
