### PR TITLE
fix: clean up earlier refactor issues with maxExtensionTime

### DIFF
--- a/src/lease-manager.ts
+++ b/src/lease-manager.ts
@@ -51,8 +51,6 @@ export interface FlowControlOptions {
  * @property {number} [maxBytes=104857600] The desired amount of memory to
  *     allow message data to consume. (Default: 100MB) It's possible that this
  *     value will be exceeded, since messages are received in batches.
- * @property {number} [maxExtensionMinutes=60] The maximum duration (in minutes)
- *     to extend the message deadline before redelivering.
  * @property {number} [maxMessages=1000] The desired number of messages to allow
  *     in memory before pausing the message stream. Unless allowExcessMessages
  *     is set to false, it is very likely that this value will be exceeded since

--- a/src/subscriber.ts
+++ b/src/subscriber.ts
@@ -1231,6 +1231,10 @@ export class Subscriber extends EventEmitter {
       );
     }
 
+    if (this._options.maxExtensionTime) {
+      this.maxExtensionTime = this._options.maxExtensionTime;
+    }
+
     if (this._inventory) {
       this._inventory.setOptions(this._options.flowControl!);
     }

--- a/test/subscriber.ts
+++ b/test/subscriber.ts
@@ -1108,6 +1108,17 @@ describe('Subscriber', () => {
 
       assert.strictEqual(stream.options.maxStreams, maxMessages);
     });
+
+    it('should pass through the max extension time', () => {
+      const maxExtensionTime = Duration.from({seconds: 1232});
+      subscriber.setOptions({
+        maxExtensionTime,
+      });
+      assert.strictEqual(
+        subscriber.maxExtensionTime.seconds,
+        maxExtensionTime.seconds,
+      );
+    });
   });
 
   describe('OpenTelemetry tracing', () => {


### PR DESCRIPTION
The `maxExtensionTime` field was not being carried over into `Subscriber`, from a refactor a while back of various settings. This fixes that and adds a unit test for it.

This also patches out an old/faulty bit of documentation about `maxExtensionMinutes`.

Fixes https://github.com/googleapis/nodejs-pubsub/issues/2054 🦕
